### PR TITLE
v1.2.1 Fix mobile_app legacy service discovery (BUG-043)

### DIFF
--- a/custom_components/ticker/discovery.py
+++ b/custom_components/ticker/discovery.py
@@ -112,7 +112,9 @@ async def async_discover_notify_services(
                     if (
                         entity.platform == "mobile_app"
                         and entity.device_id
-                        and service_name in entity.entity_id
+                        and entity.domain == "device_tracker"
+                        and service_name.removeprefix("mobile_app_")
+                        in entity.entity_id
                     ):
                         if entity.device_id not in device_notify_services:
                             device_notify_services[entity.device_id] = []


### PR DESCRIPTION
discovery.py has three paths to find notify services. All three fail for the mobile_app Companion App because it registers a legacy service (notify.mobile_app_<slug>), not a notify entity in the entity registry. This affects every current HA install using the Companion App — which is essentially every Ticker user.

Specifically, replace the Path 2 matching condition from:
if (
    entity.platform == "mobile_app"
    and entity.device_id
    and service_name in entity.entity_id
):

to:

if (
    entity.platform == "mobile_app"
    and entity.device_id
    and entity.domain == "device_tracker"
    and service_name.removeprefix("mobile_app_") in entity.entity_id
):