### PR TITLE
fix: avoid false 'Name required' when changing default mode

### DIFF
--- a/custom_components/ticker/frontend/admin/categories-tab.js
+++ b/custom_components/ticker/frontend/admin/categories-tab.js
@@ -292,11 +292,15 @@ window.Ticker.AdminCategoriesTab = {
     },
 
     async save(panel, categoryId) {
-      const name = panel.shadowRoot.getElementById(`edit-name-${categoryId}`)?.value?.trim();
-      const icon = panel.shadowRoot.getElementById(`edit-icon-${categoryId}`)?.value?.trim();
-      const color = panel.shadowRoot.getElementById(`edit-color-${categoryId}`)?.value || null;
+      const cat = panel._categories.find(c => c.id === categoryId);
+      const nameInput = panel.shadowRoot.getElementById(`edit-name-${categoryId}`);
+      const iconInput = panel.shadowRoot.getElementById(`edit-icon-${categoryId}`);
+      const colorInput = panel.shadowRoot.getElementById(`edit-color-${categoryId}`);
+      const name = nameInput?.value?.trim() || cat?.name || '';
+      const icon = iconInput?.value?.trim() || cat?.icon;
+      const color = colorInput?.value || cat?.color || null;
       const defaultModeEl = panel.shadowRoot.getElementById(`edit-default-mode-${categoryId}`);
-      const defaultMode = defaultModeEl?.value || 'always';
+      const defaultMode = defaultModeEl?.value || cat?.default_mode || 'always';
 
       if (!name) { panel._showError('Name required'); return; }
 


### PR DESCRIPTION
## Bug
https://github.com/analytix-energy-solutions/ticker/issues/8 — saving a category after switching default mode to conditional could fail with "Name required".

## Fix
`save()` was reading the name/icon/color only from the General tab inputs. When saving from the Default Mode tab, those inputs are not mounted, so `name` became empty and validation failed.

This PR falls back to the existing category values when tab-specific inputs are absent, so mode-only edits can be saved safely.

## Testing
- Verified `save()` now works when invoked from the Default Mode tab.
- Verified General tab edits still use current form values.
- Verified validation still blocks truly unnamed categories.

Happy to address any feedback.

Greetings, saschabuehrle
