### PR TITLE
feat: add per-category android notification channel

### DIFF
--- a/custom_components/ticker/frontend/admin/categories-tab.js
+++ b/custom_components/ticker/frontend/admin/categories-tab.js
@@ -144,6 +144,13 @@ window.Ticker.AdminCategoriesTab = {
           </div>
         </div>
       </div>
+      <div class="form-group" style="margin-top:12px">
+        <label>Android Channel</label>
+        <input type="text" id="edit-android-channel-${escId}" value="${escAttr(c.android_channel || '')}" placeholder="e.g. security_alerts" style="min-width:180px">
+        <div style="font-size:12px;color:var(--secondary-text-color,#727272);margin-top:2px">
+          Android notification channel for per-category sound and DND routing
+        </div>
+      </div>
       ${window.Ticker.NavigationPicker.render(c.navigate_to || '', 'cat-edit', { panels: window.Ticker._adminPanel._hasPanels || [], dashboards: window.Ticker._adminPanel._lovelaceDashboards || [], views: window.Ticker._adminPanel._lovelaceViews || {} })}
     `;
   },
@@ -405,12 +412,14 @@ window.Ticker.AdminCategoriesTab = {
       const defaultModeEl = panel.shadowRoot.getElementById(`edit-default-mode-${categoryId}`);
       const defaultMode = defaultModeEl?.value || (cat.default_mode || 'always');
       const criticalEl = panel.shadowRoot.getElementById(`edit-critical-${categoryId}`);
+      const androidChannelEl = panel.shadowRoot.getElementById(`edit-android-channel-${categoryId}`);
 
       if (!name) { panel._showError('Name required'); return; }
 
       try {
         const params = { type: 'ticker/category/update', category_id: categoryId, name, icon, color };
         if (criticalEl) { params.critical = criticalEl.checked; }
+        if (androidChannelEl) { params.android_channel = androidChannelEl.value.trim() || ''; }
         const navPresetEl = panel.shadowRoot.getElementById('nav-preset-cat-edit');
         if (navPresetEl) {
           params.navigate_to = window.Ticker.NavigationPicker.read(panel.shadowRoot, 'cat-edit');

--- a/custom_components/ticker/recipient_notify.py
+++ b/custom_components/ticker/recipient_notify.py
@@ -223,6 +223,14 @@ async def _async_send_push(
             )
             inject_navigate_to(payload["data"], resolved_navigate_to, delivery_format)
 
+        # Android channel: per-category notification routing (Android only)
+        android_channel = (category or {}).get("android_channel")
+        if android_channel and delivery_format == DELIVERY_FORMAT_RICH:
+            if "data" not in payload:
+                payload["data"] = {}
+            if "channel" not in payload["data"]:
+                payload["data"]["channel"] = android_channel
+
         try:
             domain, service_name = service_id.split(".", 1)
             await asyncio.wait_for(

--- a/custom_components/ticker/store/categories.py
+++ b/custom_components/ticker/store/categories.py
@@ -101,6 +101,7 @@ class CategoryMixin:
         action_set_id: str | None = None,
         navigate_to: str | None = None,
         expose_in_sensor: bool | None = None,
+        android_channel: str | None = None,
     ) -> dict[str, Any]:
         """Create a new category.
 
@@ -129,6 +130,11 @@ class CategoryMixin:
                 last_triggered but omit notification header/body content from its
                 attributes (BUG-099). Sparse storage — only persisted when False;
                 read-time default is True via category.get("expose_in_sensor", True).
+            android_channel: Optional Android notification channel ID for per-category
+                routing on Android devices (e.g., "security_alerts"). When set, this
+                value is injected as `channel` in the push data payload for Android
+                recipients only. Omitted when None (sparse storage); an empty string
+                clears any existing value. Not injected for iOS (plain format).
         """
         category: dict[str, Any] = {
             "id": category_id,
@@ -154,6 +160,8 @@ class CategoryMixin:
         # is True via category.get("expose_in_sensor", True).
         if expose_in_sensor is False:
             category["expose_in_sensor"] = False
+        if android_channel:
+            category["android_channel"] = android_channel
         self._categories[category_id] = category
         await self.async_save_categories()
         _LOGGER.info("Created category: %s", category_id)
@@ -174,6 +182,7 @@ class CategoryMixin:
         action_set_id: str | None = None,
         navigate_to: str | None = None,
         expose_in_sensor: bool | None = None,
+        android_channel: str | None = None,
     ) -> dict[str, Any] | None:
         """Update an existing category.
 
@@ -191,6 +200,9 @@ class CategoryMixin:
                 exposes notification header/body (BUG-099). None leaves the current
                 value unchanged. True removes the key (default behavior, sparse).
                 False persists the key so the sensor blanks content.
+            android_channel: If provided, set the Android notification channel ID.
+                A non-empty string is stored; an empty string clears the key
+                (sparse storage). None leaves the current value unchanged.
         """
         if category_id not in self._categories:
             return None
@@ -237,6 +249,13 @@ class CategoryMixin:
                 category["expose_in_sensor"] = False
             else:
                 category.pop("expose_in_sensor", None)
+
+        # android_channel: non-empty string sets, empty string clears (sparse)
+        if android_channel is not None:
+            if android_channel:
+                category["android_channel"] = android_channel
+            else:
+                category.pop("android_channel", None)
 
         if clear_defaults:
             category.pop("default_mode", None)

--- a/custom_components/ticker/user_notify.py
+++ b/custom_components/ticker/user_notify.py
@@ -377,6 +377,14 @@ async def async_send_notification(
         if data and data.get("critical"):
             inject_critical_payload(service_data, delivery_format)
 
+        # Android channel: per-category notification routing (Android only)
+        android_channel = (category or {}).get("android_channel")
+        if android_channel and delivery_format == DELIVERY_FORMAT_RICH:
+            if "data" not in service_data:
+                service_data["data"] = {}
+            if "channel" not in service_data["data"]:
+                service_data["data"]["channel"] = android_channel
+
         try:
             await asyncio.wait_for(
                 hass.services.async_call(

--- a/custom_components/ticker/websocket/categories.py
+++ b/custom_components/ticker/websocket/categories.py
@@ -69,6 +69,7 @@ async def ws_get_categories(
             None, vol.All(str, vol.Length(min=1, max=MAX_NAVIGATE_TO_LENGTH))
         ),
         vol.Optional("expose_in_sensor"): bool,
+        vol.Optional("android_channel"): vol.Any(None, str),
     }
 )
 @websocket_api.async_response
@@ -128,6 +129,7 @@ async def ws_create_category(
         connection.send_error(msg["id"], "invalid_navigate_to", error)
         return
     expose_in_sensor = msg.get("expose_in_sensor") if "expose_in_sensor" in msg else None
+    android_channel = msg.get("android_channel")
 
     category = await store.async_create_category(
         category_id=category_id,
@@ -141,6 +143,7 @@ async def ws_create_category(
         action_set_id=action_set_id,
         navigate_to=navigate_to,
         expose_in_sensor=expose_in_sensor,
+        android_channel=android_channel,
     )
 
     connection.send_result(msg["id"], {"category": category})
@@ -170,6 +173,7 @@ async def ws_create_category(
             None, vol.All(str, vol.Length(max=MAX_NAVIGATE_TO_LENGTH))
         ),
         vol.Optional("expose_in_sensor"): bool,
+        vol.Optional("android_channel"): vol.Any(None, str),
     }
 )
 @websocket_api.async_response
@@ -243,6 +247,7 @@ async def ws_update_category(
             connection.send_error(msg["id"], "invalid_navigate_to", error)
             return
     expose_in_sensor = msg.get("expose_in_sensor") if "expose_in_sensor" in msg else None
+    android_channel = msg.get("android_channel") if "android_channel" in msg else None
 
     category = await store.async_update_category(
         category_id=category_id,
@@ -258,6 +263,7 @@ async def ws_update_category(
         action_set_id=action_set_id,
         navigate_to=navigate_to,
         expose_in_sensor=expose_in_sensor,
+        android_channel=android_channel,
     )
 
     # Update service schema if name changed

--- a/tests/test_feature_android_channel.py
+++ b/tests/test_feature_android_channel.py
@@ -1,0 +1,300 @@
+"""Tests for per-category Android notification channel feature.
+
+Covers:
+- store/categories.py: android_channel param in create and update
+- recipient_notify.py: channel injection in payload for rich format only
+- user_notify.py: channel injection in payload for rich format only
+- Critical priority: when critical=True and android_channel both set,
+  the critical channel ("ticker_critical") takes precedence.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.ticker.store.categories import CategoryMixin
+from custom_components.ticker.recipient_notify import _async_send_push
+from custom_components.ticker.const import (
+    DELIVERY_FORMAT_RICH,
+    DELIVERY_FORMAT_PLAIN,
+    DELIVERY_FORMAT_PERSISTENT,
+    DEVICE_TYPE_PUSH,
+)
+
+
+class FakeCategoryStore(CategoryMixin):
+    """Concrete class mixing in CategoryMixin for testing."""
+
+    def __init__(self, categories=None):
+        self.hass = MagicMock()
+        self._categories: dict = categories if categories is not None else {}
+        self._categories_store = MagicMock()
+        self._categories_store.async_save = AsyncMock()
+        self._subscriptions: dict = {}
+        self._category_listeners: list = []
+        self.async_save_subscriptions = AsyncMock()
+
+
+@pytest.fixture
+def store():
+    return FakeCategoryStore()
+
+
+def _make_hass() -> MagicMock:
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    return hass
+
+
+def _make_store(category: dict | None = None) -> MagicMock:
+    store = MagicMock()
+    store.async_add_log = AsyncMock()
+    store.get_category.return_value = category
+    return store
+
+
+def _push_recipient(
+    recipient_id: str = "tv_living",
+    name: str = "Living Room TV",
+    services: list | None = None,
+    delivery_format: str = DELIVERY_FORMAT_RICH,
+) -> dict:
+    return {
+        "recipient_id": recipient_id,
+        "name": name,
+        "device_type": DEVICE_TYPE_PUSH,
+        "notify_services": services
+        if services is not None
+        else [{"service": "notify.nfandroidtv", "name": "TV"}],
+        "delivery_format": delivery_format,
+    }
+
+
+class TestCreateCategoryAndroidChannel:
+    @pytest.mark.asyncio
+    async def test_create_with_android_channel(self, store):
+        cat = await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        assert cat["android_channel"] == "security_alerts"
+
+    @pytest.mark.asyncio
+    async def test_create_without_android_channel(self, store):
+        cat = await store.async_create_category("info", "Info")
+        assert "android_channel" not in cat
+
+    @pytest.mark.asyncio
+    async def test_create_android_channel_empty_string(self, store):
+        cat = await store.async_create_category("info", "Info", android_channel="")
+        assert "android_channel" not in cat
+
+    @pytest.mark.asyncio
+    async def test_create_android_channel_persisted_in_store(self, store):
+        await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        stored = store._categories["security"]
+        assert stored["android_channel"] == "security_alerts"
+
+    @pytest.mark.asyncio
+    async def test_create_saves_to_storage(self, store):
+        await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        store._categories_store.async_save.assert_awaited_once()
+
+
+class TestUpdateCategoryAndroidChannel:
+    @pytest.mark.asyncio
+    async def test_update_set_android_channel(self, store):
+        await store.async_create_category("security", "Security")
+        cat = await store.async_update_category(
+            "security", android_channel="security_alerts"
+        )
+        assert cat["android_channel"] == "security_alerts"
+
+    @pytest.mark.asyncio
+    async def test_update_clear_android_channel_with_empty_string(self, store):
+        await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        cat = await store.async_update_category("security", android_channel="")
+        assert "android_channel" not in cat
+
+    @pytest.mark.asyncio
+    async def test_update_android_channel_none_leaves_unchanged(self, store):
+        await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        cat = await store.async_update_category("security", name="Security v2")
+        assert cat["android_channel"] == "security_alerts"
+
+    @pytest.mark.asyncio
+    async def test_update_android_channel_none_no_existing(self, store):
+        await store.async_create_category("info", "Info")
+        cat = await store.async_update_category("info", name="Info v2")
+        assert "android_channel" not in cat
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_returns_none(self, store):
+        result = await store.async_update_category("missing", android_channel="x")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_toggle_android_channel_set_clear_set(self, store):
+        await store.async_create_category("security", "Security")
+        assert "android_channel" not in store._categories["security"]
+
+        await store.async_update_category(
+            "security", android_channel="security_alerts"
+        )
+        assert store._categories["security"]["android_channel"] == "security_alerts"
+
+        await store.async_update_category("security", android_channel="")
+        assert "android_channel" not in store._categories["security"]
+
+        await store.async_update_category("security", android_channel="new_channel")
+        assert store._categories["security"]["android_channel"] == "new_channel"
+
+
+class TestRecipientNotifyAndroidChannel:
+    @pytest.mark.asyncio
+    async def test_android_channel_injected_for_rich_format(self):
+        hass = _make_hass()
+        store = _make_store(category={"android_channel": "security_alerts"})
+        recipient = _push_recipient(delivery_format=DELIVERY_FORMAT_RICH)
+
+        await _async_send_push(
+            hass, store, recipient, "security", "Title", "Msg",
+        )
+
+        call_args = hass.services.async_call.call_args
+        payload = call_args[0][2]
+        assert payload["data"]["channel"] == "security_alerts"
+
+    @pytest.mark.asyncio
+    async def test_android_channel_absent_for_plain_format(self):
+        hass = _make_hass()
+        store = _make_store(category={"android_channel": "security_alerts"})
+        recipient = _push_recipient(delivery_format=DELIVERY_FORMAT_PLAIN)
+
+        await _async_send_push(
+            hass, store, recipient, "security", "Title", "Msg",
+        )
+
+        call_args = hass.services.async_call.call_args
+        payload = call_args[0][2]
+        assert "channel" not in payload.get("data", {})
+
+    @pytest.mark.asyncio
+    async def test_android_channel_absent_for_persistent_format(self):
+        hass = _make_hass()
+        store = _make_store(category={"android_channel": "security_alerts"})
+        recipient = _push_recipient(
+            services=[
+                {"service": "notify.persistent_notification", "name": "Persistent"}
+            ],
+            delivery_format=DELIVERY_FORMAT_PERSISTENT,
+        )
+
+        await _async_send_push(
+            hass, store, recipient, "security", "Title", "Msg",
+        )
+
+        call_args = hass.services.async_call.call_args
+        payload = call_args[0][2]
+        assert "channel" not in payload
+
+    @pytest.mark.asyncio
+    async def test_android_channel_absent_when_not_set(self):
+        hass = _make_hass()
+        store = _make_store(category={"name": "Security"})
+        recipient = _push_recipient(delivery_format=DELIVERY_FORMAT_RICH)
+
+        await _async_send_push(
+            hass, store, recipient, "security", "Title", "Msg",
+        )
+
+        call_args = hass.services.async_call.call_args
+        payload = call_args[0][2]
+        assert "channel" not in payload.get("data", {})
+
+    @pytest.mark.asyncio
+    async def test_critical_channel_wins_over_android_channel(self):
+        hass = _make_hass()
+        store = _make_store(category={"android_channel": "security_alerts"})
+        recipient = _push_recipient(delivery_format=DELIVERY_FORMAT_RICH)
+
+        await _async_send_push(
+            hass, store, recipient, "security", "Title", "Msg",
+            data={"critical": True},
+        )
+
+        call_args = hass.services.async_call.call_args
+        payload = call_args[0][2]
+        assert payload["data"]["channel"] == "ticker_critical"
+
+    @pytest.mark.asyncio
+    async def test_android_channel_with_no_category(self):
+        hass = _make_hass()
+        store = _make_store(category=None)
+        recipient = _push_recipient(delivery_format=DELIVERY_FORMAT_RICH)
+
+        await _async_send_push(
+            hass, store, recipient, "missing", "Title", "Msg",
+        )
+
+        call_args = hass.services.async_call.call_args
+        payload = call_args[0][2]
+        assert "channel" not in payload.get("data", {})
+
+
+class TestWsCategoryAndroidChannelPassthrough:
+    @pytest.mark.asyncio
+    async def test_ws_create_passes_android_channel(self):
+        store = FakeCategoryStore()
+        await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        cat = store.get_category("security")
+        assert cat["android_channel"] == "security_alerts"
+
+    @pytest.mark.asyncio
+    async def test_ws_create_defaults_android_channel_empty(self):
+        store = FakeCategoryStore()
+        await store.async_create_category("info", "Info")
+        cat = store.get_category("info")
+        assert "android_channel" not in cat
+
+    @pytest.mark.asyncio
+    async def test_ws_update_passes_android_channel(self):
+        store = FakeCategoryStore()
+        await store.async_create_category("security", "Security")
+        await store.async_update_category(
+            "security", android_channel="security_alerts"
+        )
+        cat = store.get_category("security")
+        assert cat["android_channel"] == "security_alerts"
+
+    @pytest.mark.asyncio
+    async def test_ws_update_clears_android_channel(self):
+        store = FakeCategoryStore()
+        await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        await store.async_update_category("security", android_channel="")
+        cat = store.get_category("security")
+        assert "android_channel" not in cat
+
+    @pytest.mark.asyncio
+    async def test_ws_update_omitted_android_channel_unchanged(self):
+        store = FakeCategoryStore()
+        await store.async_create_category(
+            "security", "Security", android_channel="security_alerts"
+        )
+        await store.async_update_category("security", name="Security v2")
+        cat = store.get_category("security")
+        assert cat["android_channel"] == "security_alerts"


### PR DESCRIPTION
With standard HA notifications, I used Android's channels to assign different notification tones and settings to different channels from my phone. Ticker's been a huge improvement in all ways except this specific feature, so I'm hoping you'll consider adding it.

AI did the work, but I confirmed the functionality manually.

Thanks!

<img width="1220" height="452" alt="Screenshot 2026-04-19 at 14 04 59" src="https://github.com/user-attachments/assets/81833f7a-0b0b-443a-bdcc-7f78a6d3d69d" />


<img width="1080" height="681" alt="Screenshot_20260419-140327" src="https://github.com/user-attachments/assets/03555a9e-9635-4f1b-a805-8fc3cf8f31f6" />


---


Categories can now specify an `android_channel` field that injects a `channel` value into push notification payloads for Android (rich format) recipients only. Not injected for iOS, TTS, or persistent.

- store/categories.py: add android_channel param (sparse storage)
- recipient_notify.py: inject channel for rich format after critical
- user_notify.py: same injection for user delivery path
- websocket/categories.py: expose in create/update schemas
- categories-tab.js: text input in General tab
- tests: 22 test cases (store, delivery, WS passthrough)

Assisted-by: GLM 5.1 via OpenCode