### PR TITLE
fix(BUG-107): user panel terminal-state escape affordance

### DIFF
--- a/custom_components/ticker/const.py
+++ b/custom_components/ticker/const.py
@@ -1,7 +1,7 @@
 """Constants for Ticker integration."""
 
 DOMAIN = "ticker"
-VERSION = "1.6.1"
+VERSION = "1.6.2"
 
 # Storage keys
 STORAGE_VERSION = 1

--- a/custom_components/ticker/frontend/ticker-panel.js
+++ b/custom_components/ticker/frontend/ticker-panel.js
@@ -363,6 +363,16 @@ class TickerPanel extends HTMLElement {
     }
   }
 
+  // BUG-107: Terminal-card render + escape navigation live in
+  // window.Ticker.UserRecoveryHandlers (user/recovery-handlers.js) to
+  // keep this file under the 500-line cap.
+  _renderTerminalCard(title, message, stateClass) {
+    return window.Ticker.UserRecoveryHandlers.renderTerminalCard(title, message, stateClass);
+  }
+  _returnToDashboard() {
+    window.Ticker.UserRecoveryHandlers.returnToDashboard();
+  }
+
   _renderTabContent() {
     if (!this._els) return;
     if (this._loading) {
@@ -380,25 +390,17 @@ class TickerPanel extends HTMLElement {
     }
     this._els.loadingArea.innerHTML = '';
     if (this._error) {
-      this._els.tabContent.innerHTML = `
-        <div class="card">
-          <div class="error-state">
-            <p>Error: ${window.Ticker.utils.esc(this._error)}</p>
-          </div>
-        </div>
-      `;
+      this._els.tabContent.innerHTML = this._renderTerminalCard(
+        'Error', `Error: ${this._error}`, 'error-state');
+      this.shadowRoot.querySelector('.terminal-card-btn')?.focus();
       return;
     }
     if (!this._currentPerson) {
-      this._els.tabContent.innerHTML = `
-        <div class="card">
-          <div class="no-person-state">
-            <h3>No Person Entity Found</h3>
-            <p>Your Home Assistant user account is not linked to a person entity.<br>
-            Ask an administrator to link your account in Settings → People.</p>
-          </div>
-        </div>
-      `;
+      this._els.tabContent.innerHTML = this._renderTerminalCard(
+        'No Person Entity Found',
+        'Your Home Assistant user account is not linked to a person entity. Ask an administrator to link your account in Settings → People.',
+        'no-person-state');
+      this.shadowRoot.querySelector('.terminal-card-btn')?.focus();
       return;
     }
     // Render tabs bar

--- a/custom_components/ticker/frontend/user/recovery-handlers.js
+++ b/custom_components/ticker/frontend/user/recovery-handlers.js
@@ -81,4 +81,44 @@ window.Ticker.UserRecoveryHandlers = {
     panel.style.display = '';
     void panel.offsetHeight;
   },
+
+  /**
+   * BUG-107: Render a terminal-state card (no-person / error) with a
+   * "Return to Dashboard" escape button. Caller is responsible for
+   * focusing `.terminal-card-btn` after the DOM is in place.
+   * @param {string} title - Card heading (escaped).
+   * @param {string} message - Card body text (escaped).
+   * @param {string} stateClass - Existing CSS class: 'no-person-state' or 'error-state'.
+   * @returns {string} innerHTML for the card.
+   */
+  renderTerminalCard(title, message, stateClass) {
+    const esc = window.Ticker.utils.esc;
+    return `
+      <div class="card">
+        <div class="${stateClass}">
+          <h3>${esc(title)}</h3>
+          <p>${esc(message)}</p>
+          <div style="margin-top: 16px;">
+            <button class="btn btn-primary terminal-card-btn"
+              onclick="window.Ticker._userPanel._returnToDashboard()">Return to Dashboard</button>
+          </div>
+        </div>
+      </div>
+    `;
+  },
+
+  /**
+   * BUG-107: Escape the user panel via `history.replaceState` so the iOS
+   * Companion App cached route no longer points at `/ticker`. Fires the
+   * HA `location-changed` event so `ha-router` resolves the new path.
+   * `replaceState` (not `pushState`) is required per SPEC_BUG-107 §4.1.
+   */
+  returnToDashboard() {
+    window.history.replaceState(null, '', '/');
+    window.dispatchEvent(new CustomEvent('location-changed', {
+      detail: { replace: true },
+      bubbles: true,
+      composed: true,
+    }));
+  },
 };

--- a/custom_components/ticker/frontend/user/user-panel-styles.js
+++ b/custom_components/ticker/frontend/user/user-panel-styles.js
@@ -205,4 +205,10 @@ window.Ticker.userPanelStyles = `
   .no-person-state { text-align: center; padding: 40px; }
   .no-person-state h3 { color: var(--text-primary); margin: 0 0 8px 0; }
   .no-person-state p { color: var(--text-secondary); margin: 0; }
+
+  /* BUG-107: Terminal-card escape button focus ring (keyboard / screen reader) */
+  .terminal-card-btn:focus-visible {
+    outline: 2px solid var(--ticker-400);
+    outline-offset: 2px;
+  }
 `;

--- a/custom_components/ticker/manifest.json
+++ b/custom_components/ticker/manifest.json
@@ -9,5 +9,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/analytix-energy-solutions/ticker/issues",
     "requirements": [],
-    "version": "1.6.1"
+    "version": "1.6.2"
 }


### PR DESCRIPTION
  Adds Return to Dashboard button to both no-person and error
  states. Uses replaceState + location-changed event so the
  iOS Companion App cached route no longer points at /ticker.

  Closes #38