### PR TITLE
fix: render sidebar menu button in narrow/portrait mode (BUG-111)

### DIFF
--- a/custom_components/ticker/frontend/ticker-admin-panel.js
+++ b/custom_components/ticker/frontend/ticker-admin-panel.js
@@ -73,6 +73,8 @@ class TickerAdminPanel extends HTMLElement {
     // DOM cache
     this._els = {};
     this._dependenciesLoaded = false;
+    // BUG-111: HA-reported narrow state, drives the sidebar toggle button.
+    this._narrow = false;
 
     // BUG-040: Scroll preservation
     this._scrollPositions = {};
@@ -85,6 +87,18 @@ class TickerAdminPanel extends HTMLElement {
       this._initialized = true;
       this._init();
     }
+  }
+
+  // BUG-111: HA passes `narrow` to panel_custom elements. Custom panels must
+  // render their own sidebar toggle; capture narrow so we can show the menu
+  // button (see _applyNarrow) only when the sidebar is a drawer (mobile).
+  set narrow(value) {
+    this._narrow = !!value;
+    this._applyNarrow();
+  }
+
+  get narrow() {
+    return this._narrow;
   }
 
   connectedCallback() {
@@ -210,6 +224,11 @@ class TickerAdminPanel extends HTMLElement {
       ${css}
       <div class="container-wide">
         <div class="header">
+          <button class="menu-button" id="ticker-admin-menu-button" type="button"
+            aria-label="Open sidebar menu" title="Menu"
+            onclick="window.Ticker._adminPanel._toggleMenu()">
+            <svg viewBox="0 0 24 24"><path d="M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z"></path></svg>
+          </button>
           ${logo}
           <h1>Ticker Admin</h1>
         </div>
@@ -223,9 +242,29 @@ class TickerAdminPanel extends HTMLElement {
       tabs: this.shadowRoot.getElementById('tabs'),
       message: this.shadowRoot.getElementById('message'),
       content: this.shadowRoot.getElementById('tab-content'),
+      menuButton: this.shadowRoot.getElementById('ticker-admin-menu-button'),
     };
+    // BUG-111: reflect the current narrow state onto the freshly-built button
+    // (narrow may have been set before this structure existed).
+    this._applyNarrow();
 
     this._renderTabs();
+  }
+
+  // BUG-111: show the hamburger only when HA reports narrow (sidebar is a
+  // drawer). When wide the sidebar is docked, so display:none keeps the logo
+  // flush-left with no layout shift.
+  _applyNarrow() {
+    const btn = this._els?.menuButton;
+    if (btn) btn.classList.toggle('visible', this._narrow);
+  }
+
+  // BUG-111: dispatch HA's global sidebar-toggle event. bubbles + composed so
+  // it escapes this panel's shadow root and reaches <home-assistant-main>.
+  _toggleMenu() {
+    this.dispatchEvent(
+      new CustomEvent('hass-toggle-menu', { bubbles: true, composed: true }),
+    );
   }
 
   _renderTabs() {

--- a/custom_components/ticker/frontend/ticker-panel.js
+++ b/custom_components/ticker/frontend/ticker-panel.js
@@ -36,6 +36,8 @@ class TickerPanel extends HTMLElement {
     this._devicePrefDirty = false;
     this._dependenciesLoaded = false;
     this._els = null;
+    // BUG-111: HA-reported narrow state, drives the sidebar toggle button.
+    this._narrow = false;
     // BUG-040: Scroll/focus preservation
     this._scrollPositions = {};
     this._pendingScrollRestore = null;
@@ -59,6 +61,18 @@ class TickerPanel extends HTMLElement {
       this._initialized = true;
       this._initialize();
     }
+  }
+
+  // BUG-111: HA passes `narrow` to panel_custom elements. Custom panels must
+  // render their own sidebar toggle; capture narrow so we can show the menu
+  // button (see _applyNarrow) only when the sidebar is a drawer (mobile).
+  set narrow(value) {
+    this._narrow = !!value;
+    this._applyNarrow();
+  }
+
+  get narrow() {
+    return this._narrow;
   }
 
   connectedCallback() {
@@ -165,7 +179,12 @@ class TickerPanel extends HTMLElement {
     this.shadowRoot.innerHTML = `
       <style>${allStyles}</style>
       <div class="container">
-        <div class="header">${logoSvg}<h1>Ticker</h1><div id="view-as-slot"></div></div>
+        <div class="header">
+          <button class="menu-button" id="ticker-menu-button" type="button"
+            aria-label="Open sidebar menu" title="Menu"
+            onclick="window.Ticker._userPanel._toggleMenu()">
+            <svg viewBox="0 0 24 24"><path d="M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z"></path></svg>
+          </button>${logoSvg}<h1>Ticker</h1><div id="view-as-slot"></div></div>
         <div id="view-as-banner-slot"></div>
         <div id="message-area" class="message"></div>
         <div id="loading-area"></div>
@@ -181,7 +200,27 @@ class TickerPanel extends HTMLElement {
       tabContent: this.shadowRoot.getElementById('tab-content'),
       viewAsSlot: this.shadowRoot.getElementById('view-as-slot'),
       viewAsBannerSlot: this.shadowRoot.getElementById('view-as-banner-slot'),
+      menuButton: this.shadowRoot.getElementById('ticker-menu-button'),
     };
+    // BUG-111: reflect the current narrow state onto the freshly-built button
+    // (narrow may have been set before this structure existed).
+    this._applyNarrow();
+  }
+
+  // BUG-111: show the hamburger only when HA reports narrow (sidebar is a
+  // drawer). When wide the sidebar is docked, so display:none keeps the logo
+  // flush-left with no layout shift.
+  _applyNarrow() {
+    const btn = this._els?.menuButton;
+    if (btn) btn.classList.toggle('visible', this._narrow);
+  }
+
+  // BUG-111: dispatch HA's global sidebar-toggle event. bubbles + composed so
+  // it escapes this panel's shadow root and reaches <home-assistant-main>.
+  _toggleMenu() {
+    this.dispatchEvent(
+      new CustomEvent('hass-toggle-menu', { bubbles: true, composed: true }),
+    );
   }
 
   async _loadData() {

--- a/custom_components/ticker/frontend/ticker-styles.js
+++ b/custom_components/ticker/frontend/ticker-styles.js
@@ -63,6 +63,43 @@ window.Ticker.styles = {
       width: 40px;
       height: 40px;
     }
+    /* BUG-111: Sidebar toggle for narrow/portrait mode. Custom panels must
+       render their own menu button; without it there is no way to open the
+       HA sidebar drawer on mobile portrait. Hidden by default (sidebar is
+       docked on wide layouts); shown via .visible when HA reports narrow. */
+    .menu-button {
+      display: none;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
+      flex: 0 0 auto;
+      width: 40px;
+      height: 40px;
+      margin-left: -8px;
+      padding: 8px;
+      border: none;
+      background: none;
+      color: var(--text-primary);
+      border-radius: 50%;
+      cursor: pointer;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .menu-button.visible {
+      display: inline-flex;
+    }
+    .menu-button:hover {
+      background: var(--ticker-500-alpha-8, rgba(6, 182, 212, 0.08));
+    }
+    .menu-button:focus-visible {
+      outline: 2px solid var(--ticker-500);
+      outline-offset: 2px;
+    }
+    .menu-button svg {
+      display: block;
+      width: 24px;
+      height: 24px;
+      fill: currentColor;
+    }
   `,
 
   /** Tabs navigation */


### PR DESCRIPTION
Fixes #51

## Problem
`ticker-panel.js` and `ticker-admin-panel.js` are `panel_custom` web components. HA renders them as the full panel and does **not** provide a toolbar, so neither panel rendered a sidebar toggle. On **mobile portrait** there was no hamburger (☰) in the top-left, leaving no way to open the HA sidebar drawer — the only escape was rotating to landscape (which docks the sidebar). Built-in pages (e.g. Energy → Electricity) render `ha-menu-button` when narrow; the Ticker panels didn't.

## Fix
- Add a `narrow` setter/getter (HA passes `narrow` to `panel_custom` elements).
- Render a hamburger `<button class="menu-button">` as the **first** header child (the flex `gap` slides the logo/title right to make room).
- `_toggleMenu()` dispatches the global `hass-toggle-menu` event with `bubbles: true, composed: true` so it escapes the panel's shadow root and reaches `<home-assistant-main>`, toggling the sidebar.
- `_applyNarrow()` shows the button only when narrow; on wide layouts the sidebar is docked so it stays `display: none` (no layout shift). `narrow` set before the DOM is built is re-applied on `_createStructure`.
- Shared `.menu-button` CSS added to the `header` style block (used by both panels).

Frontend only — vanilla JS, no build step, no Python changes.

## Testing
- `node --check` on all three changed files.
- jsdom smoke test for **both** panels: button renders as first header child; hidden when `!narrow`, shown when `narrow`; a click dispatches a bubbling + composed `hass-toggle-menu`; `narrow` set before build is honored on structure creation. (22/22 assertions pass.)
- Deployed to a live HA instance and served/parsed cleanly.

## Files
- `custom_components/ticker/frontend/ticker-styles.js` — `.menu-button` styles
- `custom_components/ticker/frontend/ticker-panel.js` — user panel
- `custom_components/ticker/frontend/ticker-admin-panel.js` — admin panel