### PR TITLE
fix: honor #history deep-link on remount and hash changes

### DIFF
--- a/custom_components/ticker/frontend/ticker-panel.js
+++ b/custom_components/ticker/frontend/ticker-panel.js
@@ -62,6 +62,19 @@ class TickerPanel extends HTMLElement {
   }
 
   connectedCallback() {
+    // Tap-to-History: honor the #history deep-link on (re)mount and on later
+    // hash navigations so notification taps reliably land on the History tab
+    // instead of the default Subscriptions tab.
+    if (window.location.hash === '#history') this._activeTab = 'history';
+    if (!this._hashHandler) {
+      this._hashHandler = () => {
+        if (window.location.hash === '#history') {
+          if (this._initialized && this._els) this._switchTab('history');
+          else this._activeTab = 'history';
+        }
+      };
+      window.addEventListener('hashchange', this._hashHandler);
+    }
     if (!this._initialized && this._hass) {
       this._initialized = true;
       this._initialize();
@@ -76,6 +89,10 @@ class TickerPanel extends HTMLElement {
   }
 
   disconnectedCallback() {
+    if (this._hashHandler) {
+      window.removeEventListener('hashchange', this._hashHandler);
+      this._hashHandler = null;
+    }
     if (this._visibilityHandler) {
       document.removeEventListener('visibilitychange', this._visibilityHandler);
       this._visibilityHandler = null;


### PR DESCRIPTION
Fixes #53

## Problem
The Ticker user panel supports a `#history` URL-hash deep-link so a notification tap can open the **History** tab directly. The hash was only read **once in the constructor**:

`this._activeTab = window.location.hash === '#history' ? 'history' : 'subscriptions';`

HA keeps `panel_custom` elements alive and reuses them, so on a **remount** (or when the hash changed while the panel was already open) the deep-link was ignored and the user landed on the default **Subscriptions** tab.

## Fix
- `connectedCallback` re-checks `window.location.hash` and selects History on (re)mount.
- A `hashchange` listener is registered while mounted: once initialized it calls `_switchTab('history')`; otherwise it sets the pending `_activeTab` so the correct tab renders on first paint.
- `disconnectedCallback` removes the listener (no leak, no post-unmount switching).

Frontend only — vanilla JS, no build step, no Python changes.

## Testing
- `node --check` on the changed file.
- jsdom smoke test (7/7 assertions): constructor honors `#history`; a hash that appears **after** construction is honored on mount; a `hashchange` while mounted switches to History; and after `disconnectedCallback` the listener is removed so no further switching occurs.

## Files
- `custom_components/ticker/frontend/ticker-panel.js`