### PR TITLE
Optional category + nested data.mode fallback on ticker.notify (iq_notify drop-in)

### DIFF
--- a/custom_components/ticker/USER_GUIDE.md
+++ b/custom_components/ticker/USER_GUIDE.md
@@ -247,6 +247,15 @@ Admins can set a default subscription mode and conditions per category. When a u
 
 Admins control *who* receives notifications per category. Users control *when* they receive them. When an admin disables a category for a user, that category is hidden from the user panel entirely. Subscriptions set by an admin are tracked separately from user-set subscriptions.
 
+### Priority fallback (per-category presence group)
+
+A category-level setting (admin panel, General tab) that narrows every `ticker.notify` call for that category to a single winning presence group, on top of each subscriber's own subscription mode and conditions. Two modes are available:
+
+- **Only home, else everyone away**: notify only persons currently home. If nobody is home, fall back to notifying everyone away instead.
+- **Just left, else everyone away**: notify only persons who left within the configured window (in minutes). If nobody just left, fall back to notifying everyone away.
+
+Persons not in the winning group are logged as skipped ("Priority fallback: not in winning group"), visible in the admin Logs tab. This setting is call-scoped, not per-subscriber: it decides which subscribers are even considered before their individual mode/conditions run. This includes subscribers on Always mode: being outside the winning group excludes them from this notification regardless of their own subscription mode. Persons whose presence is not currently known (device tracker offline, or not yet reported in after a restart) are excluded from both groups rather than guessed.
+
 ---
 
 ## Conditional rules

--- a/custom_components/ticker/USER_GUIDE.md
+++ b/custom_components/ticker/USER_GUIDE.md
@@ -290,7 +290,7 @@ Rule: (this person) = home, within 10m       # just arrived
 Rule: (this person) = not_home, for ≥ 15m    # been away a while
 ```
 
-Duration rules that use "For at least" and are not yet met are automatically re-checked the moment their threshold is crossed, even with no underlying state change — no need to also add a Time rule to catch it.
+When "Queue until conditions met" is enabled, a "For at least" duration rule that is not yet met is automatically re-checked the moment its threshold is crossed, even with no underlying state change: no need to also add a Time rule to catch it. This re-check relies on the queue mechanism, so it does not apply to a "Deliver when conditions met"-only subscription with no queueing.
 
 ### Condition-level toggles
 

--- a/custom_components/ticker/USER_GUIDE.md
+++ b/custom_components/ticker/USER_GUIDE.md
@@ -280,6 +280,18 @@ Rule: Time = 08:00–22:00, Mon–Fri
 Rule: binary_sensor.tv_power = off
 ```
 
+**Duration** — Evaluates how long an entity has held a given state. Leave the entity field blank to default to the subscriber's own person entity. Two comparisons are available:
+
+- **Within N minutes** — the entity transitioned into the target state at most N minutes ago (e.g. "just arrived home", "just left").
+- **For at least N minutes** — the entity has held the target state continuously for at least N minutes (e.g. "staying home", "staying away").
+
+```
+Rule: (this person) = home, within 10m       # just arrived
+Rule: (this person) = not_home, for ≥ 15m    # been away a while
+```
+
+Duration rules that use "For at least" and are not yet met are automatically re-checked the moment their threshold is crossed, even with no underlying state change — no need to also add a Time rule to catch it.
+
 ### Condition-level toggles
 
 The "deliver when met" and "queue until met" toggles apply to the entire set of rules, not to individual rules. For example:

--- a/custom_components/ticker/condition_listeners.py
+++ b/custom_components/ticker/condition_listeners.py
@@ -237,16 +237,25 @@ class ConditionListenerManager:
                 if before:
                     all_times.add(before)
 
-            # Duration ("for_at_least") leaves become true at a fixed future
-            # timestamp with no state-change event to trigger re-evaluation.
-            # Resolve each leaf's effective entity (blank defaults to this
-            # subscription's person) and, if it's currently sitting in the
-            # target state below threshold, note when it will cross it.
+            # Duration leaves: resolve each leaf's effective entity (blank
+            # defaults to this subscription's person) and register it for
+            # entity-change listening regardless of comparison. A "within"
+            # leaf needs to react to the entity transitioning just as much
+            # as a "state" leaf does.
+            durations = triggers.get("durations", [])
+            if not durations:
+                continue
             person_id = sub.get("person_id") if not is_recipient else None
-            for duration in triggers.get("durations", []):
+            for duration in durations:
+                entity_id = duration.get("entity_id") or person_id
+                if entity_id:
+                    all_entities.add(entity_id)
+
+                # "for_at_least" leaves additionally become true at a fixed
+                # future timestamp with no state-change event to trigger
+                # re-evaluation, so also note when the threshold is crossed.
                 if duration.get("comparison") != DURATION_COMPARISON_FOR_AT_LEAST:
                     continue
-                entity_id = duration.get("entity_id") or person_id
                 target_state = duration.get("state")
                 minutes = duration.get("minutes")
                 if not entity_id or not target_state or not minutes:
@@ -420,6 +429,10 @@ class ConditionListenerManager:
     async def _async_reevaluate_for_entity(self, entity_id: str) -> None:
         """Re-evaluate subscriptions affected by an entity change.
 
+        Also refreshes listeners: an entity transitioning into a duration
+        leaf's target state is exactly when a "for_at_least" wakeup needs
+        to be (re)scheduled, and refresh is where that computation lives.
+
         Args:
             entity_id: The entity that changed
         """
@@ -427,6 +440,7 @@ class ConditionListenerManager:
             filter_type=RULE_TYPE_STATE,
             filter_value=entity_id,
         )
+        await self.async_refresh_listeners()
 
     async def _async_reevaluate_for_time(self, time_str: str) -> None:
         """Re-evaluate subscriptions affected by a time trigger.

--- a/custom_components/ticker/condition_listeners.py
+++ b/custom_components/ticker/condition_listeners.py
@@ -7,6 +7,7 @@ queued notifications and release them when conditions are met.
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Callable
 
 from homeassistant.core import HomeAssistant, callback, Event
@@ -19,7 +20,9 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     CONDITION_NODE_GROUP,
+    DURATION_COMPARISON_FOR_AT_LEAST,
     MODE_CONDITIONAL,
+    RULE_TYPE_DURATION,
     RULE_TYPE_STATE,
     RULE_TYPE_TIME,
     RULE_TYPE_ZONE,
@@ -56,6 +59,7 @@ def _leaf_matches_filter(
     leaf: dict[str, Any],
     filter_type: str,
     filter_value: str | None,
+    person_id: str | None = None,
 ) -> bool:
     """Check if a leaf node matches a filter type and value.
 
@@ -63,14 +67,26 @@ def _leaf_matches_filter(
         leaf: A leaf condition node.
         filter_type: Rule type to match (e.g. RULE_TYPE_STATE).
         filter_value: Value to match (entity_id or time string).
+        person_id: The subscription's person_id, used to resolve a
+            duration leaf's blank ``entity_id`` (defaults to the person)
+            when matching against an entity-change filter.
 
     Returns:
         True if the leaf matches the filter criteria.
     """
-    if leaf.get("type") != filter_type:
-        return False
+    leaf_type = leaf.get("type")
     if filter_type == RULE_TYPE_STATE:
-        return leaf.get("entity_id") == filter_value
+        # Duration leaves are tracked via the same entity-change listener
+        # as state leaves (no dedicated "duration" listener type), so an
+        # entity-change filter must also match duration leaves.
+        if leaf_type == RULE_TYPE_STATE:
+            return leaf.get("entity_id") == filter_value
+        if leaf_type == RULE_TYPE_DURATION:
+            entity_id = leaf.get("entity_id") or person_id
+            return entity_id == filter_value
+        return False
+    if leaf_type != filter_type:
+        return False
     if filter_type == RULE_TYPE_TIME:
         # BUG-096: match either edge of the time window so `before`
         # triggers re-evaluate subscriptions too.
@@ -119,6 +135,13 @@ class ConditionListenerManager:
         # Debounced refresh state (BUG-086)
         self._pending_refresh_unsub: Callable[[], None] | None = None
 
+        # Duration rule wakeup: "for_at_least" duration leaves become true
+        # at a fixed future timestamp with no underlying state-change event
+        # to trigger re-evaluation. A single timer is scheduled for the
+        # earliest such timestamp across all conditional subscriptions and
+        # recomputed on every listener refresh (see _schedule_duration_wakeup).
+        self._duration_wakeup_unsub: Callable[[], None] | None = None
+
         # BUG-106: one-shot post-startup queue sweep state.
         self._startup_swept: bool = False
         self._was_starting_at_register: bool = not hass.is_running
@@ -164,6 +187,7 @@ class ConditionListenerManager:
         # Collect all triggers from conditional subscriptions
         all_entities: set[str] = set()
         all_times: set[str] = set()
+        next_duration_wakeup: datetime | None = None
 
         # Scan all subscriptions for conditional rules
         # This includes both person-based and recipient-based subscriptions.
@@ -213,6 +237,31 @@ class ConditionListenerManager:
                 if before:
                     all_times.add(before)
 
+            # Duration ("for_at_least") leaves become true at a fixed future
+            # timestamp with no state-change event to trigger re-evaluation.
+            # Resolve each leaf's effective entity (blank defaults to this
+            # subscription's person) and, if it's currently sitting in the
+            # target state below threshold, note when it will cross it.
+            person_id = sub.get("person_id") if not is_recipient else None
+            for duration in triggers.get("durations", []):
+                if duration.get("comparison") != DURATION_COMPARISON_FOR_AT_LEAST:
+                    continue
+                entity_id = duration.get("entity_id") or person_id
+                target_state = duration.get("state")
+                minutes = duration.get("minutes")
+                if not entity_id or not target_state or not minutes:
+                    continue
+
+                state = self.hass.states.get(entity_id)
+                if state is None or state.state.lower() != str(target_state).lower():
+                    continue
+
+                wake_at = state.last_changed + timedelta(minutes=minutes)
+                if wake_at <= dt_util.utcnow():
+                    continue  # threshold already crossed
+                if next_duration_wakeup is None or wake_at < next_duration_wakeup:
+                    next_duration_wakeup = wake_at
+
         # Set up entity listeners
         if all_entities:
             self._setup_entity_listeners(list(all_entities))
@@ -221,11 +270,40 @@ class ConditionListenerManager:
         if all_times:
             self._setup_time_listeners(list(all_times))
 
+        # Set up (or clear) the duration wakeup timer
+        if next_duration_wakeup is not None:
+            self._schedule_duration_wakeup(next_duration_wakeup)
+        elif self._duration_wakeup_unsub is not None:
+            self._duration_wakeup_unsub()
+            self._duration_wakeup_unsub = None
+
         _LOGGER.debug(
             "Refreshed condition listeners: %d entities, %d times",
             len(all_entities),
             len(all_times),
         )
+
+    def _schedule_duration_wakeup(self, wake_at: datetime) -> None:
+        """Schedule a one-shot timer to re-evaluate at ``wake_at``.
+
+        Only one duration wakeup timer is ever active: it targets the
+        earliest pending "for_at_least" threshold across all conditional
+        subscriptions. When it fires, a full sweep re-evaluates everything
+        and ``async_refresh_listeners`` recomputes (and reschedules) the
+        next-earliest wakeup, so later thresholds are not missed.
+        """
+        if self._duration_wakeup_unsub is not None:
+            self._duration_wakeup_unsub()
+            self._duration_wakeup_unsub = None
+
+        delay = max((wake_at - dt_util.utcnow()).total_seconds(), 0.1)
+
+        async def _on_wakeup(_now: Any) -> None:
+            self._duration_wakeup_unsub = None
+            await self._async_reevaluate_subscriptions()
+            await self.async_refresh_listeners()
+
+        self._duration_wakeup_unsub = async_call_later(self.hass, delay, _on_wakeup)
 
     def _cleanup_listeners(self) -> None:
         """Clean up all existing listeners."""
@@ -407,7 +485,7 @@ class ConditionListenerManager:
             if filter_type:
                 leaves = _collect_leaves(tree) if tree else list(rules)
                 has_matching_rule = any(
-                    _leaf_matches_filter(leaf, filter_type, filter_value)
+                    _leaf_matches_filter(leaf, filter_type, filter_value, person_id)
                     for leaf in leaves
                 )
                 if not has_matching_rule:
@@ -492,6 +570,10 @@ class ConditionListenerManager:
         if self._pending_refresh_unsub is not None:
             self._pending_refresh_unsub()
             self._pending_refresh_unsub = None
+
+        if self._duration_wakeup_unsub is not None:
+            self._duration_wakeup_unsub()
+            self._duration_wakeup_unsub = None
 
         self._cleanup_listeners()
         _LOGGER.debug("Condition listeners unloaded")

--- a/custom_components/ticker/conditions.py
+++ b/custom_components/ticker/conditions.py
@@ -7,7 +7,7 @@ Legacy flat rules[] format is supported as fallback.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
@@ -16,9 +16,12 @@ from homeassistant.util import dt as dt_util
 from .conditions_legacy import convert_legacy_zones_to_rules  # noqa: F401
 from .const import (
     CONDITION_NODE_GROUP,
+    DURATION_COMPARISON_FOR_AT_LEAST,
+    DURATION_COMPARISON_WITHIN,
     RULE_TYPE_ZONE,
     RULE_TYPE_TIME,
     RULE_TYPE_STATE,
+    RULE_TYPE_DURATION,
 )
 
 if TYPE_CHECKING:
@@ -155,6 +158,72 @@ def evaluate_state_rule(
     return False, f"{entity_id} is {state.state}, not {expected_state}"
 
 
+def evaluate_duration_rule(
+    hass: HomeAssistant,
+    rule: dict[str, Any],
+    person_state: "State | None" = None,
+    now: datetime | None = None,
+) -> tuple[bool, str]:
+    """Evaluate a duration rule: how long an entity has held a given state.
+
+    ``comparison`` selects the semantics:
+      * "within" (default) — the entity transitioned into ``state`` at most
+        ``minutes`` ago (e.g. "just arrived home").
+      * "for_at_least" — the entity has held ``state`` continuously for at
+        least ``minutes`` (e.g. "staying home").
+
+    ``entity_id`` is optional: when omitted, the rule defaults to the
+    subscription's own person entity (mirrors the zone rule's implicit
+    subject). Explicit ``entity_id`` also works for non-person subjects
+    (e.g. recipient conditions), since it does not depend on person_state.
+
+    Returns (is_met, reason).
+    """
+    if now is None:
+        now = dt_util.now()
+
+    entity_id = rule.get("entity_id") or ""
+    if not entity_id and person_state is not None:
+        entity_id = person_state.entity_id
+
+    if not entity_id:
+        return False, "No entity_id specified for duration rule"
+
+    target_state = rule.get("state", "")
+    if not target_state:
+        return False, "No target state specified for duration rule"
+
+    minutes = rule.get("minutes")
+    if not isinstance(minutes, (int, float)) or isinstance(minutes, bool) or minutes <= 0:
+        return False, "Duration rule requires a positive 'minutes' value"
+
+    comparison = rule.get("comparison", DURATION_COMPARISON_WITHIN)
+
+    state = hass.states.get(entity_id)
+    if state is None:
+        return False, f"Entity {entity_id} not found"
+
+    actual_state = state.state.lower()
+    expected_state = str(target_state).lower()
+    if actual_state != expected_state:
+        return False, f"{entity_id} is {state.state}, not {target_state}"
+
+    elapsed = now - state.last_changed
+    elapsed_minutes = int(elapsed.total_seconds() // 60)
+    threshold = timedelta(minutes=minutes)
+
+    if comparison == DURATION_COMPARISON_FOR_AT_LEAST:
+        is_met = elapsed >= threshold
+        if is_met:
+            return True, f"{entity_id} has been {target_state} for {elapsed_minutes}m (>= {int(minutes)}m)"
+        return False, f"{entity_id} has been {target_state} for only {elapsed_minutes}m (< {int(minutes)}m)"
+
+    is_met = elapsed <= threshold
+    if is_met:
+        return True, f"{entity_id} became {target_state} {elapsed_minutes}m ago (<= {int(minutes)}m)"
+    return False, f"{entity_id} became {target_state} {elapsed_minutes}m ago (> {int(minutes)}m)"
+
+
 def evaluate_rule(
     hass: HomeAssistant,
     rule: dict[str, Any],
@@ -173,6 +242,8 @@ def evaluate_rule(
         return evaluate_time_rule(rule, now)
     elif rule_type == RULE_TYPE_STATE:
         return evaluate_state_rule(hass, rule)
+    elif rule_type == RULE_TYPE_DURATION:
+        return evaluate_duration_rule(hass, rule, person_state, now)
     else:
         _LOGGER.debug("Unknown rule type '%s', treating as unmet", rule_type)
         return False, f"Unknown rule type: {rule_type}"
@@ -378,6 +449,21 @@ def _collect_triggers_from_node(
         entity_id = node.get("entity_id", "")
         if entity_id:
             triggers["entities"].add(entity_id)
+    elif node.get("type") == RULE_TYPE_DURATION:
+        entity_id = node.get("entity_id", "")
+        if entity_id:
+            triggers["entities"].add(entity_id)
+        # Duration leaves may become true/false at a point in time with no
+        # underlying state change (e.g. "for_at_least" crossing its
+        # threshold), so callers also need the raw rule to schedule a
+        # time-based wakeup. Collected regardless of entity_id being blank
+        # (person-default is resolved by the caller, which knows person_id).
+        triggers.setdefault("durations", []).append({
+            "entity_id": entity_id,
+            "state": node.get("state", ""),
+            "comparison": node.get("comparison", "within"),
+            "minutes": node.get("minutes"),
+        })
     elif node.get("type") == RULE_TYPE_TIME:
         after = node.get("after", "")
         if after:
@@ -396,6 +482,7 @@ def get_queue_triggers(
         "zones": set(),
         "entities": set(),
         "time_windows": [],
+        "durations": [],
     }
 
     # Only collect triggers if queueing is enabled

--- a/custom_components/ticker/conditions.py
+++ b/custom_components/ticker/conditions.py
@@ -167,9 +167,9 @@ def evaluate_duration_rule(
     """Evaluate a duration rule: how long an entity has held a given state.
 
     ``comparison`` selects the semantics:
-      * "within" (default) — the entity transitioned into ``state`` at most
+      * "within" (default): the entity transitioned into ``state`` at most
         ``minutes`` ago (e.g. "just arrived home").
-      * "for_at_least" — the entity has held ``state`` continuously for at
+      * "for_at_least": the entity has held ``state`` continuously for at
         least ``minutes`` (e.g. "staying home").
 
     ``entity_id`` is optional: when omitted, the rule defaults to the
@@ -177,17 +177,24 @@ def evaluate_duration_rule(
     subject). Explicit ``entity_id`` also works for non-person subjects
     (e.g. recipient conditions), since it does not depend on person_state.
 
+    When ``entity_id`` is blank and no ``person_state`` is available
+    (recipient conditions have no location), the rule is skipped and
+    treated as met, mirroring the zone rule's "no person context" fallback:
+    a recipient's blank-entity duration leaf would otherwise be silently
+    and permanently unmet with no way for the admin to fix it, since
+    recipients have no person entity to default to.
+
     Returns (is_met, reason).
     """
     if now is None:
         now = dt_util.now()
 
     entity_id = rule.get("entity_id") or ""
-    if not entity_id and person_state is not None:
-        entity_id = person_state.entity_id
-
     if not entity_id:
-        return False, "No entity_id specified for duration rule"
+        if person_state is not None:
+            entity_id = person_state.entity_id
+        else:
+            return True, "Duration rule skipped (no person context for blank entity_id)"
 
     target_state = rule.get("state", "")
     if not target_state:
@@ -211,17 +218,11 @@ def evaluate_duration_rule(
     elapsed = now - state.last_changed
     elapsed_minutes = int(elapsed.total_seconds() // 60)
     threshold = timedelta(minutes=minutes)
+    for_at_least = comparison == DURATION_COMPARISON_FOR_AT_LEAST
 
-    if comparison == DURATION_COMPARISON_FOR_AT_LEAST:
-        is_met = elapsed >= threshold
-        if is_met:
-            return True, f"{entity_id} has been {target_state} for {elapsed_minutes}m (>= {int(minutes)}m)"
-        return False, f"{entity_id} has been {target_state} for only {elapsed_minutes}m (< {int(minutes)}m)"
-
-    is_met = elapsed <= threshold
-    if is_met:
-        return True, f"{entity_id} became {target_state} {elapsed_minutes}m ago (<= {int(minutes)}m)"
-    return False, f"{entity_id} became {target_state} {elapsed_minutes}m ago (> {int(minutes)}m)"
+    is_met = elapsed >= threshold if for_at_least else elapsed <= threshold
+    comparator = (">=" if is_met else "<") if for_at_least else ("<=" if is_met else ">")
+    return is_met, f"{entity_id} has been {target_state} for {elapsed_minutes}m ({comparator} {int(minutes)}m threshold)"
 
 
 def evaluate_rule(

--- a/custom_components/ticker/const.py
+++ b/custom_components/ticker/const.py
@@ -65,6 +65,35 @@ PRIORITY_FALLBACK_MODES = [
 DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES = 2
 MAX_PRIORITY_FALLBACK_WINDOW_MINUTES = 1440  # 24 hours
 
+# Per-call routing modes (drop-in parity port of iq_notify's send-time
+# `mode`). Passed on the ticker.notify service to filter recipients by
+# presence for a single call, overriding the category's static
+# priority_fallback. See mode_routing.resolve_mode_group.
+ROUTE_MODE_ALL = "all"
+ROUTE_MODE_ONLY_HOME = "only_home"
+ROUTE_MODE_ONLY_AWAY = "only_away"
+ROUTE_MODE_JUST_ARRIVED = "just_arrived"
+ROUTE_MODE_JUST_LEFT = "just_left"
+ROUTE_MODE_STAYING_HOME = "staying_home"
+ROUTE_MODE_STAYING_AWAY = "staying_away"
+# The two "then_away" modes share their implementation with the category
+# priority_fallback of the same name (see mode_routing / priority_fallback).
+ROUTE_MODE_ONLY_HOME_THEN_AWAY = PRIORITY_FALLBACK_ONLY_HOME_THEN_AWAY
+ROUTE_MODE_JUST_LEFT_THEN_AWAY = PRIORITY_FALLBACK_JUST_LEFT_THEN_AWAY
+ROUTE_MODE_NOBODY_HOME = "nobody_home"
+ROUTE_MODES = [
+    ROUTE_MODE_ALL,
+    ROUTE_MODE_ONLY_HOME,
+    ROUTE_MODE_ONLY_AWAY,
+    ROUTE_MODE_JUST_ARRIVED,
+    ROUTE_MODE_JUST_LEFT,
+    ROUTE_MODE_STAYING_HOME,
+    ROUTE_MODE_STAYING_AWAY,
+    ROUTE_MODE_ONLY_HOME_THEN_AWAY,
+    ROUTE_MODE_JUST_LEFT_THEN_AWAY,
+    ROUTE_MODE_NOBODY_HOME,
+]
+
 # Condition tree (F-2b AND/OR grouping)
 CONDITION_NODE_GROUP = "group"
 CONDITION_OPERATOR_AND = "AND"
@@ -93,6 +122,8 @@ ATTR_TITLE = "title"
 ATTR_MESSAGE = "message"
 ATTR_EXPIRATION = "expiration"
 ATTR_DATA = "data"
+ATTR_MODE = "mode"
+ATTR_MODE_WINDOW = "mode_window"
 
 # Queue defaults
 DEFAULT_EXPIRATION_HOURS = 48

--- a/custom_components/ticker/const.py
+++ b/custom_components/ticker/const.py
@@ -51,6 +51,20 @@ DURATION_COMPARISON_FOR_AT_LEAST = "for_at_least"
 DURATION_COMPARISONS = [DURATION_COMPARISON_WITHIN, DURATION_COMPARISON_FOR_AT_LEAST]
 MAX_DURATION_MINUTES = 1440  # 24 hours
 
+# Priority fallback (F-fork: category-level presence fallback)
+# "only_home_then_away": notify only persons currently home; if none are
+#   home, fall back to notifying everyone away instead.
+# "just_left_then_away": notify only persons who left within
+#   window_minutes; if none just left, fall back to everyone away.
+PRIORITY_FALLBACK_ONLY_HOME_THEN_AWAY = "only_home_then_away"
+PRIORITY_FALLBACK_JUST_LEFT_THEN_AWAY = "just_left_then_away"
+PRIORITY_FALLBACK_MODES = [
+    PRIORITY_FALLBACK_ONLY_HOME_THEN_AWAY,
+    PRIORITY_FALLBACK_JUST_LEFT_THEN_AWAY,
+]
+DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES = 2
+MAX_PRIORITY_FALLBACK_WINDOW_MINUTES = 1440  # 24 hours
+
 # Condition tree (F-2b AND/OR grouping)
 CONDITION_NODE_GROUP = "group"
 CONDITION_OPERATOR_AND = "AND"

--- a/custom_components/ticker/const.py
+++ b/custom_components/ticker/const.py
@@ -40,7 +40,16 @@ DEFAULT_CONDITION_ZONE = "zone.home"
 RULE_TYPE_ZONE = "zone"
 RULE_TYPE_TIME = "time"
 RULE_TYPE_STATE = "state"
-RULE_TYPES = [RULE_TYPE_ZONE, RULE_TYPE_TIME, RULE_TYPE_STATE]
+RULE_TYPE_DURATION = "duration"
+RULE_TYPES = [RULE_TYPE_ZONE, RULE_TYPE_TIME, RULE_TYPE_STATE, RULE_TYPE_DURATION]
+
+# Duration rule comparisons (F-fork: Duration Rule Type)
+# "within": entity has been in `state` for at most `minutes` (just transitioned)
+# "for_at_least": entity has been in `state` for at least `minutes` (staying)
+DURATION_COMPARISON_WITHIN = "within"
+DURATION_COMPARISON_FOR_AT_LEAST = "for_at_least"
+DURATION_COMPARISONS = [DURATION_COMPARISON_WITHIN, DURATION_COMPARISON_FOR_AT_LEAST]
+MAX_DURATION_MINUTES = 1440  # 24 hours
 
 # Condition tree (F-2b AND/OR grouping)
 CONDITION_NODE_GROUP = "group"

--- a/custom_components/ticker/frontend/admin/categories-handlers.js
+++ b/custom_components/ticker/frontend/admin/categories-handlers.js
@@ -134,6 +134,14 @@ window.Ticker.AdminCategoriesTab.handlers = {
     } catch (err) { panel._showError(err.message); }
   },
 
+  /** Toggle the window-minutes input's visibility with the mode select. */
+  priorityFallbackModeChanged(panel, categoryId) {
+    const root = panel.shadowRoot;
+    const modeEl = root.getElementById(`edit-priority-fallback-mode-${categoryId}`);
+    const wrap = root.getElementById(`priority-fallback-window-wrap-${categoryId}`);
+    if (wrap) wrap.style.display = (modeEl && modeEl.value !== 'none') ? '' : 'none';
+  },
+
   async save(panel, categoryId) {
     const cat = panel._categories.find(c => c.id === categoryId);
     if (!cat) return;
@@ -172,6 +180,18 @@ window.Ticker.AdminCategoriesTab.handlers = {
       // Always send the field on edit so cleared sliders flush prior overrides.
       const volume = window.Ticker.AdminVolumeOverride.read(`cat-${categoryId}`);
       params.volume_override = volume;  // null clears, float sets
+
+      // Priority fallback (F-fork): always send the field on edit so
+      // switching back to "none" clears any prior override.
+      const priorityModeEl = root.getElementById(`edit-priority-fallback-mode-${categoryId}`);
+      const priorityMode = priorityModeEl ? priorityModeEl.value : 'none';
+      if (priorityMode === 'none') {
+        params.priority_fallback = null;
+      } else {
+        const windowEl = root.getElementById(`edit-priority-fallback-window-${categoryId}`);
+        const windowMinutes = windowEl ? parseInt(windowEl.value, 10) || 2 : 2;
+        params.priority_fallback = { mode: priorityMode, window_minutes: windowMinutes };
+      }
 
       if (defaultMode === 'conditional') {
         params.default_mode = 'conditional';

--- a/custom_components/ticker/frontend/admin/categories-tab.js
+++ b/custom_components/ticker/frontend/admin/categories-tab.js
@@ -151,9 +151,46 @@ window.Ticker.AdminCategoriesTab = {
           Android notification channel for per-category sound and DND routing
         </div>
       </div>
+      ${this._renderPriorityFallbackBlock(c, escId)}
       ${this._renderCategoryVolumeBlock(c, escId)}
       ${this._renderCategoryChimeBlock(c, escId)}
       ${window.Ticker.NavigationPicker.render(c.navigate_to || '', 'cat-edit', { panels: window.Ticker._adminPanel._hasPanels || [], dashboards: window.Ticker._adminPanel._lovelaceDashboards || [], views: window.Ticker._adminPanel._lovelaceViews || {} })}
+    `;
+  },
+
+  /**
+   * Priority fallback block (F-fork, ported from iq_notify): try a
+   * primary presence group first, and fall back to notifying everyone
+   * away only when the primary group is empty. Applies to every
+   * ticker.notify call for this category, on top of each subscriber's
+   * own subscription mode/conditions.
+   */
+  _renderPriorityFallbackBlock(c, escId) {
+    const { escAttr } = window.Ticker.utils;
+    const fallback = c.priority_fallback || {};
+    const mode = fallback.mode || 'none';
+    const windowMinutes = (typeof fallback.window_minutes === 'number' && fallback.window_minutes > 0)
+      ? fallback.window_minutes : 2;
+    const opt = (value, label) =>
+      `<option value="${value}" ${mode === value ? 'selected' : ''}>${label}</option>`;
+    return `
+      <div class="form-group" style="margin-top:12px">
+        <label>Priority Fallback</label>
+        <div class="form-row">
+          <select id="edit-priority-fallback-mode-${escId}" style="min-width:220px" onchange="window.Ticker.AdminCategoriesTab.handlers.priorityFallbackModeChanged(window.Ticker._adminPanel, '${escId}')">
+            ${opt('none', 'Off (notify everyone as usual)')}
+            ${opt('only_home_then_away', 'Only home, else everyone away')}
+            ${opt('just_left_then_away', 'Just left, else everyone away')}
+          </select>
+          <div class="form-group" id="priority-fallback-window-wrap-${escId}" style="${mode === 'none' ? 'display:none' : ''}">
+            <input type="number" id="edit-priority-fallback-window-${escId}" min="1" max="1440" value="${escAttr(String(windowMinutes))}" style="width:80px">
+            <span style="font-size:12px;color:var(--secondary-text-color,#727272)">min window</span>
+          </div>
+        </div>
+        <div style="font-size:12px;color:var(--secondary-text-color,#727272);margin-top:2px">
+          Tries the primary group first for every notification in this category; falls back to everyone away only when the primary group is empty. Ported from iq_notify's only_home_then_away / just_left_then_away.
+        </div>
+      </div>
     `;
   },
 

--- a/custom_components/ticker/frontend/ticker-conditions-tree.js
+++ b/custom_components/ticker/frontend/ticker-conditions-tree.js
@@ -265,6 +265,7 @@ window.Ticker.conditionsTree = {
       if (node.type === 'zone' && !node.zone_id) return null;
       if (node.type === 'time' && (!node.after || !node.before)) return null;
       if (node.type === 'state' && (!node.entity_id || !node.state)) return null;
+      if (node.type === 'duration' && (!node.state || !node.minutes)) return null;
       return node;
     }
     var self = this;

--- a/custom_components/ticker/frontend/ticker-conditions-ui.js
+++ b/custom_components/ticker/frontend/ticker-conditions-ui.js
@@ -78,6 +78,7 @@ class TickerConditionsUI extends HTMLElement {
     if (type==='zone') r.zone_id = this._zones.length ? this._zones[0].zone_id : 'zone.home';
     else if (type==='time') { r.after='08:00'; r.before='22:00'; r.days=[1,2,3,4,5,6,7]; }
     else if (type==='state') { r.entity_id=''; r.state=''; }
+    else if (type==='duration') { r.entity_id=''; r.state=''; r.comparison='within'; r.minutes=15; }
     const t = this._clone(this._tree);
     if (!t.children.length) { this._deliverWhenMet=true; this._queueUntilMet=!this._hideQueue; }
     t.children.push(r);
@@ -242,7 +243,7 @@ class TickerConditionsUI extends HTMLElement {
         return { values: fallback(), freeform: true };
     }
   }
-  _typeName(t) { return {zone:'Zone',time:'Time',state:'Entity State'}[t]||t; }
+  _typeName(t) { return {zone:'Zone',time:'Time',state:'Entity State',duration:'Duration'}[t]||t; }
   _summary(r) {
     const base = this._summaryRaw(r);
     return r && r.negate === true ? this._negatedLabel(r.type, base) : base;
@@ -252,6 +253,12 @@ class TickerConditionsUI extends HTMLElement {
     if(r.type==='time'){const dn=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
       const ds=(r.days||[]).map(d=>dn[d-1]).join(', ');return `${r.after} - ${r.before}${ds?` (${ds})`:''}`;  }
     if(r.type==='state') return r.entity_id?`${r.entity_id} = ${r.state}`:'Not configured';
+    if(r.type==='duration'){
+      if(!r.state||!r.minutes) return 'Not configured';
+      const who=r.entity_id||'this person';
+      const cmp=r.comparison==='for_at_least'?'for ≥':'within';
+      return `${who} = ${r.state} ${cmp} ${r.minutes}m`;
+    }
     return 'Unknown';
   }
   // F-33: per-type NOT placement convention (ASCII != for state per Hans).
@@ -281,6 +288,7 @@ class TickerConditionsUI extends HTMLElement {
     const add=`<div class="add-rule-section">${zb}
       <button class="add-rule-btn" data-action="add-time" ${this._disabled?'disabled':''}>+ Time</button>
       <button class="add-rule-btn" data-action="add-state" ${this._disabled?'disabled':''}>+ Entity State</button>
+      <button class="add-rule-btn" data-action="add-duration" ${this._disabled?'disabled':''}>+ Duration</button>
     </div>${this._infoText()}`;
     const acts=leaves.length?this._actionsHtml():'';
     this.shadowRoot.innerHTML=`${styles}${content}${add}${acts}`;
@@ -291,7 +299,7 @@ class TickerConditionsUI extends HTMLElement {
     const sr=this.shadowRoot;
     sr.querySelectorAll('.add-rule-btn').forEach(b=>b.addEventListener('click',()=>{
       const a=b.dataset.action;
-      if(a==='add-zone')this._addRule('zone');else if(a==='add-time')this._addRule('time');else if(a==='add-state')this._addRule('state');
+      if(a==='add-zone')this._addRule('zone');else if(a==='add-time')this._addRule('time');else if(a==='add-state')this._addRule('state');else if(a==='add-duration')this._addRule('duration');
     }));
     sr.querySelectorAll('.operator-pill:not(.group-op-pill)').forEach(p=>p.addEventListener('click',()=>this._toggleOperator(JSON.parse(p.dataset.parentpath))));
     sr.querySelectorAll('.group-btn').forEach(b=>{if(!b.disabled)b.addEventListener('click',()=>this._groupAt(JSON.parse(b.dataset.parentpath),parseInt(b.dataset.childidx)));});
@@ -308,6 +316,8 @@ class TickerConditionsUI extends HTMLElement {
     sr.querySelectorAll('[data-day-toggle]').forEach(b=>b.addEventListener('click',()=>this._toggleDayAt(JSON.parse(b.dataset.dayPath),parseInt(b.dataset.dayToggle))));
     sr.querySelectorAll('[data-entity-path]').forEach(i=>i.addEventListener('input',()=>this._onEntityInput(i.dataset.entityPath,i.value)));
     sr.querySelectorAll('[data-state-path]').forEach(s=>s.addEventListener('change',()=>this._updateRuleAt(JSON.parse(s.dataset.statePath),'state',s.value)));
+    sr.querySelectorAll('[data-duration-comparison-path]').forEach(s=>s.addEventListener('change',()=>this._updateRuleAt(JSON.parse(s.dataset.durationComparisonPath),'comparison',s.value)));
+    sr.querySelectorAll('[data-duration-minutes-path]').forEach(i=>i.addEventListener('change',()=>this._updateRuleAt(JSON.parse(i.dataset.durationMinutesPath),'minutes',parseInt(i.value,10)||1)));
   }
 
   _renderChildren(children, pp) {
@@ -372,6 +382,24 @@ class TickerConditionsUI extends HTMLElement {
         `<datalist id="entity-list-${pid}"></datalist></div><div class="form-group" style="flex:1"><label class="form-label">State</label>`+
         `<select class="form-select" id="state-select-${pid}" data-state-path='${ps}' ${da}><option value=""${!cur?' selected':''}>Select state...</option>${co}${so}</select></div></div>`+
         `<div class="state-help-text">Suggestions are based on the selected entity. Any value is accepted.</div></div>`;}
+    if(rule.type==='duration'){const pid=ps.replace(/[\[\],]/g,'_');
+      const ent=this._findEntity(rule.entity_id);
+      const sg=TickerConditionsUI.getStateOptions(ent,this._zones).values;
+      const cur=rule.state||'',hc=!cur||sg.includes(cur);
+      const co=!hc?`<option value="${this._escAttr(cur)}" selected>${this._esc(cur)}</option>`:'';
+      const so=sg.map(s=>`<option value="${this._escAttr(s)}" ${s===cur?'selected':''}>${this._esc(s)}</option>`).join('');
+      const cmp=rule.comparison||'within';
+      return `<div class="rule-content"><div class="form-row"><div class="form-group" style="flex:2"><label class="form-label">Entity (blank = this person)</label>`+
+        `<input type="text" class="form-input" list="entity-list-${pid}" id="entity-input-${pid}" placeholder="Leave blank to use the subscriber" value="${this._escAttr(rule.entity_id||'')}" data-entity-path='${ps}' ${da}>`+
+        `<datalist id="entity-list-${pid}"></datalist></div><div class="form-group" style="flex:1"><label class="form-label">State</label>`+
+        `<select class="form-select" id="state-select-${pid}" data-state-path='${ps}' ${da}><option value=""${!cur?' selected':''}>Select state...</option>${co}${so}</select></div></div>`+
+        `<div class="form-row"><div class="form-group"><label class="form-label">Comparison</label>`+
+        `<select class="form-select" data-duration-comparison-path='${ps}' ${da}>`+
+        `<option value="within" ${cmp==='within'?'selected':''}>Within last N minutes (just changed)</option>`+
+        `<option value="for_at_least" ${cmp==='for_at_least'?'selected':''}>For at least N minutes (staying)</option>`+
+        `</select></div><div class="form-group"><label class="form-label">Minutes</label>`+
+        `<input type="number" class="form-input" min="1" max="1440" value="${this._escAttr(rule.minutes||15)}" data-duration-minutes-path='${ps}' ${da}></div></div>`+
+        `<div class="state-help-text">If entity is left blank, this rule checks the subscriber's own person entity.</div></div>`;}
     return '';
   }
   _infoText() {

--- a/custom_components/ticker/frontend/ticker-conditions-ui.js
+++ b/custom_components/ticker/frontend/ticker-conditions-ui.js
@@ -383,7 +383,11 @@ class TickerConditionsUI extends HTMLElement {
         `<select class="form-select" id="state-select-${pid}" data-state-path='${ps}' ${da}><option value=""${!cur?' selected':''}>Select state...</option>${co}${so}</select></div></div>`+
         `<div class="state-help-text">Suggestions are based on the selected entity. Any value is accepted.</div></div>`;}
     if(rule.type==='duration'){const pid=ps.replace(/[\[\],]/g,'_');
-      const ent=this._findEntity(rule.entity_id);
+      // Blank entity_id defaults to the subscriber's own person entity at
+      // evaluation time, so there is no real entity to look up here.
+      // Synthesize a 'person' domain so the state dropdown still offers
+      // home/not_home/zone suggestions instead of coming up empty.
+      const ent=rule.entity_id?this._findEntity(rule.entity_id):{domain:'person'};
       const sg=TickerConditionsUI.getStateOptions(ent,this._zones).values;
       const cur=rule.state||'',hc=!cur||sg.includes(cur);
       const co=!hc?`<option value="${this._escAttr(cur)}" selected>${this._esc(cur)}</option>`:'';

--- a/custom_components/ticker/mode_routing.py
+++ b/custom_components/ticker/mode_routing.py
@@ -1,0 +1,110 @@
+"""Per-call routing modes (drop-in parity port of iq_notify's send-time `mode`).
+
+Ticker categories carry a *static* ``priority_fallback``; iq_notify instead
+took a per-call ``mode`` that filtered recipients by presence at send time.
+This module reproduces the full iq_notify mode set as a per-call override,
+evaluated against the person ``State`` list before subscription/condition
+resolution.
+
+The two "then_away" fallback modes delegate to
+``priority_fallback.resolve_priority_group`` so the category-level and
+per-call code paths share a single implementation.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from .const import (
+    DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES,
+    ROUTE_MODE_ALL,
+    ROUTE_MODE_JUST_ARRIVED,
+    ROUTE_MODE_JUST_LEFT,
+    ROUTE_MODE_JUST_LEFT_THEN_AWAY,
+    ROUTE_MODE_NOBODY_HOME,
+    ROUTE_MODE_ONLY_AWAY,
+    ROUTE_MODE_ONLY_HOME,
+    ROUTE_MODE_ONLY_HOME_THEN_AWAY,
+    ROUTE_MODE_STAYING_AWAY,
+    ROUTE_MODE_STAYING_HOME,
+)
+from .priority_fallback import resolve_priority_group
+
+# Matches HA's person entity state literally; kept consistent with
+# priority_fallback.py rather than importing from homeassistant.const.
+_HOME_STATE = "home"
+_UNRESOLVED_STATES = ("unknown", "unavailable")
+
+_THEN_AWAY_MODES = (
+    ROUTE_MODE_ONLY_HOME_THEN_AWAY,
+    ROUTE_MODE_JUST_LEFT_THEN_AWAY,
+)
+
+
+def _window(window_minutes) -> timedelta:
+    """Coerce a raw window value to a timedelta, defaulting on garbage.
+
+    Mirrors resolve_priority_group's defensiveness: this reads a value that
+    originates from a service call, so a malformed ``window_minutes`` degrades
+    to the default rather than raising.
+    """
+    if not isinstance(window_minutes, (int, float)) or isinstance(window_minutes, bool):
+        window_minutes = DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES
+    return timedelta(minutes=window_minutes)
+
+
+def resolve_mode_group(persons: list, mode: str, window_minutes, now) -> list:
+    """Return the subset of ``persons`` a per-call routing ``mode`` should notify.
+
+    Ported from ``iq_notify.send_message``. Presence classification mirrors
+    ``resolve_priority_group``: persons in an unknown/unavailable state are
+    never classified as home or away, so presence-scoped modes never select
+    them.
+
+    An unrecognized mode returns ``persons`` unchanged (fail-open, same
+    contract as ``resolve_priority_group``) so an unexpected value degrades to
+    "notify everyone" rather than silently dropping the notification.
+
+    Args:
+        persons: All person ``State`` objects for this notify call.
+        mode: One of ``const.ROUTE_MODES``.
+        window_minutes: Recency window for the ``just_*`` / ``staying_*`` /
+            ``just_left_then_away`` modes. Ignored by the others.
+        now: Current tz-aware time, for the recency comparisons.
+
+    Returns:
+        The subset of ``persons`` to notify.
+    """
+    if mode in (None, ROUTE_MODE_ALL):
+        return persons
+
+    if mode in _THEN_AWAY_MODES:
+        return resolve_priority_group(
+            persons, {"mode": mode, "window_minutes": window_minutes}, now,
+        )
+
+    known = [p for p in persons if p.state not in _UNRESOLVED_STATES]
+    home = [p for p in known if p.state == _HOME_STATE]
+    away = [p for p in known if p.state != _HOME_STATE]
+
+    if mode == ROUTE_MODE_ONLY_HOME:
+        return home
+    if mode == ROUTE_MODE_ONLY_AWAY:
+        return away
+    if mode == ROUTE_MODE_NOBODY_HOME:
+        # Everyone (with known presence) is notified, but only when no one is
+        # home at all; if anyone is home, no one is notified.
+        return [] if home else known
+
+    threshold = _window(window_minutes)
+
+    if mode == ROUTE_MODE_JUST_ARRIVED:
+        return [p for p in home if now - p.last_changed <= threshold]
+    if mode == ROUTE_MODE_JUST_LEFT:
+        return [p for p in away if now - p.last_changed <= threshold]
+    if mode == ROUTE_MODE_STAYING_HOME:
+        return [p for p in home if now - p.last_changed > threshold]
+    if mode == ROUTE_MODE_STAYING_AWAY:
+        return [p for p in away if now - p.last_changed > threshold]
+
+    return persons

--- a/custom_components/ticker/notify.py
+++ b/custom_components/ticker/notify.py
@@ -60,6 +60,11 @@ class TickerNotifyEntity(NotifyEntity):
         # Copy to avoid mutating the caller's dict
         data = dict(kwargs.get("data") or {})
         category = data.pop("category", CATEGORY_DEFAULT)
+        # F-fork: allow per-call routing mode through the notify entity path
+        # (drop-in parity with iq_notify). Pulled out of data so it reaches the
+        # ticker.notify service as a top-level field.
+        mode = data.pop("mode", None)
+        mode_window = data.pop("mode_window", None)
 
         service_data: dict[str, object] = {
             "message": message,
@@ -69,6 +74,10 @@ class TickerNotifyEntity(NotifyEntity):
             service_data["title"] = title
         else:
             service_data["title"] = "Notification"
+        if mode is not None:
+            service_data["mode"] = mode
+        if mode_window is not None:
+            service_data["mode_window"] = mode_window
         if data:
             service_data["data"] = data
 

--- a/custom_components/ticker/priority_fallback.py
+++ b/custom_components/ticker/priority_fallback.py
@@ -1,0 +1,79 @@
+"""Category-level priority fallback (F-fork, ported from iq_notify).
+
+Split out of services.py to keep that file under the project's ~500-line
+convention (mirrors the frontend admin panel's tab.js/handlers.js split).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from .const import (
+    DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES,
+    PRIORITY_FALLBACK_JUST_LEFT_THEN_AWAY,
+    PRIORITY_FALLBACK_ONLY_HOME_THEN_AWAY,
+)
+
+
+def resolve_priority_group(
+    persons: list,
+    priority_fallback: dict[str, Any],
+    now,
+) -> list:
+    """Resolve which persons a priority-fallback category should notify.
+
+    Ported from iq_notify's only_home_then_away / just_left_then_away
+    modes: try a primary group first, and fall back to everyone away only
+    when the primary group is empty.
+
+    - "only_home_then_away": primary = persons currently home.
+    - "just_left_then_away": primary = persons away who transitioned away
+      within window_minutes.
+
+    In both cases the fallback group is everyone away, since the primary
+    group being empty means (by construction) no one who is home would be
+    in the fallback anyway.
+
+    Persons whose presence is not actually known ("unknown"/"unavailable",
+    e.g. a device tracker offline or not yet reported in after HA restart)
+    are excluded from both groups: we cannot classify them as home or away,
+    so they are never selected by this fallback either way.
+
+    Args:
+        persons: All person State objects for the category's notify call.
+        priority_fallback: {"mode": ..., "window_minutes": ...}.
+        now: Current time (tz-aware), for the just_left window comparison.
+
+    Returns:
+        The subset of `persons` that should be notified. Returns `persons`
+        unchanged if `mode` is not recognized, or if `window_minutes` is
+        malformed for "just_left_then_away" (defensive: this reads a raw
+        stored dict, not one freshly validated by the store layer).
+    """
+    mode = priority_fallback.get("mode")
+    # Matches HA's person entity state literally; not imported from
+    # homeassistant.const to stay consistent with the rest of this codebase
+    # (see conditions.py's zone-matching notes on person.state comparisons).
+    home_state = "home"
+    unresolved_states = ("unknown", "unavailable")
+    known = [p for p in persons if p.state not in unresolved_states]
+
+    if mode == PRIORITY_FALLBACK_ONLY_HOME_THEN_AWAY:
+        home = [p for p in known if p.state == home_state]
+        if home:
+            return home
+        return [p for p in known if p.state != home_state]
+
+    if mode == PRIORITY_FALLBACK_JUST_LEFT_THEN_AWAY:
+        window_minutes = priority_fallback.get(
+            "window_minutes", DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES,
+        )
+        if not isinstance(window_minutes, (int, float)) or isinstance(window_minutes, bool):
+            window_minutes = DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES
+        away = [p for p in known if p.state != home_state]
+        threshold = timedelta(minutes=window_minutes)
+        just_left = [p for p in away if now - p.last_changed <= threshold]
+        return just_left if just_left else away
+
+    return persons

--- a/custom_components/ticker/service_schema.py
+++ b/custom_components/ticker/service_schema.py
@@ -27,6 +27,7 @@ from .const import (
     MAX_NAVIGATE_TO_LENGTH,
     MAX_PRIORITY_FALLBACK_WINDOW_MINUTES,
     ROUTE_MODES,
+    CATEGORY_DEFAULT,
     CATEGORY_DEFAULT_NAME,
 )
 from .websocket.validation import validate_navigate_to_vol
@@ -56,7 +57,11 @@ def _build_service_schema() -> vol.Schema:
         {
             # F-27: accept single category ID/name or list for fan-out.
             # The UI selector stays single-dropdown; multi only via YAML.
-            vol.Required(ATTR_CATEGORY): vol.Any(cv.string, [cv.string]),
+            # F-fork: optional so an iq_notify drop-in call without a category
+            # lands in the default category instead of erroring.
+            vol.Optional(ATTR_CATEGORY, default=CATEGORY_DEFAULT): vol.Any(
+                cv.string, [cv.string]
+            ),
             vol.Required(ATTR_TITLE): cv.string,
             vol.Required(ATTR_MESSAGE): cv.string,
             vol.Optional(ATTR_EXPIRATION, default=DEFAULT_EXPIRATION_HOURS): vol.All(

--- a/custom_components/ticker/service_schema.py
+++ b/custom_components/ticker/service_schema.py
@@ -18,11 +18,15 @@ from .const import (
     ATTR_ACTIONS,
     ATTR_ACTION_SET_ID,
     ATTR_CRITICAL,
+    ATTR_MODE,
+    ATTR_MODE_WINDOW,
     ATTR_NAVIGATE_TO,
     ATTR_CLEAR_WHEN,
     DEFAULT_EXPIRATION_HOURS,
     MAX_EXPIRATION_HOURS,
     MAX_NAVIGATE_TO_LENGTH,
+    MAX_PRIORITY_FALLBACK_WINDOW_MINUTES,
+    ROUTE_MODES,
     CATEGORY_DEFAULT_NAME,
 )
 from .websocket.validation import validate_navigate_to_vol
@@ -65,6 +69,15 @@ def _build_service_schema() -> vol.Schema:
             # falls back to the category default), so no validation here.
             vol.Optional(ATTR_ACTION_SET_ID): cv.string,
             vol.Optional(ATTR_CRITICAL): bool,
+            # F-fork: per-call routing mode (drop-in parity with iq_notify).
+            # Filters recipients by presence for this call, overriding the
+            # category's static priority_fallback. mode_window is the recency
+            # window (minutes) for the just_*/staying_*/just_left_then_away modes.
+            vol.Optional(ATTR_MODE): vol.In(ROUTE_MODES),
+            vol.Optional(ATTR_MODE_WINDOW): vol.All(
+                vol.Coerce(int),
+                vol.Range(min=1, max=MAX_PRIORITY_FALLBACK_WINDOW_MINUTES),
+            ),
             # BUG-100: enforce relative HA path; blocks javascript:/http(s)://
             vol.Optional(ATTR_NAVIGATE_TO): vol.All(
                 cv.string,

--- a/custom_components/ticker/services.py
+++ b/custom_components/ticker/services.py
@@ -36,6 +36,7 @@ from .const import (
 from .service_schema import _build_service_schema, _build_service_description
 from .conditions import evaluate_condition_tree
 from .formatting import build_smart_tag
+from .priority_fallback import resolve_priority_group
 from .user_notify import async_handle_conditional_notification, async_send_notification
 from .recipient_notify import (
     async_send_to_recipient,
@@ -265,7 +266,39 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             "dropped": [],
         }
 
-        for person_state in persons:
+        # Priority fallback (F-fork, ported from iq_notify): a category-level
+        # "only_home_then_away" / "just_left_then_away" mode narrows the
+        # person list to a single winning presence group for this call,
+        # before subscription mode/conditions are evaluated per person.
+        dispatch_persons = persons
+        priority_fallback = (category or {}).get("priority_fallback")
+        if priority_fallback:
+            dispatch_persons = resolve_priority_group(
+                persons, priority_fallback, dt_util.utcnow(),
+            )
+            winning_ids = {p.entity_id for p in dispatch_persons}
+            # Disabled users are already silently skipped by the
+            # is_user_enabled check below with no log entry; don't log a
+            # misleading "not in winning group" reason for them too.
+            skipped_ids = [
+                p.entity_id for p in persons
+                if p.entity_id not in winning_ids
+                and store.is_user_enabled(p.entity_id)
+            ]
+            for skipped_id in skipped_ids:
+                await store.async_add_log(
+                    category_id=category_id,
+                    person_id=skipped_id,
+                    person_name=_get_person_name(hass, skipped_id),
+                    title=title,
+                    message=message,
+                    outcome=LOG_OUTCOME_SKIPPED,
+                    reason=f"Priority fallback ({priority_fallback.get('mode')}): not in winning group",
+                    notification_id=notification_id,
+                )
+                delivery_results["dropped"].append(f"{skipped_id}: priority fallback")
+
+        for person_state in dispatch_persons:
             person_id = person_state.entity_id
             person_name = person_state.attributes.get("friendly_name", person_id)
 

--- a/custom_components/ticker/services.py
+++ b/custom_components/ticker/services.py
@@ -24,12 +24,15 @@ from .const import (
     ATTR_ACTIONS,
     ATTR_ACTION_SET_ID,
     ATTR_CRITICAL,
+    ATTR_MODE,
+    ATTR_MODE_WINDOW,
     ATTR_NAVIGATE_TO,
     ATTR_CLEAR_WHEN,
     DEFAULT_EXPIRATION_HOURS,
     MODE_ALWAYS,
     MODE_NEVER,
     MODE_CONDITIONAL,
+    ROUTE_MODE_ALL,
     LOG_OUTCOME_SKIPPED,
     SMART_TAG_MODE_NONE,
 )
@@ -37,6 +40,7 @@ from .service_schema import _build_service_schema, _build_service_description
 from .conditions import evaluate_condition_tree
 from .formatting import build_smart_tag
 from .priority_fallback import resolve_priority_group
+from .mode_routing import resolve_mode_group
 from .user_notify import async_handle_conditional_notification, async_send_notification
 from .recipient_notify import (
     async_send_to_recipient,
@@ -134,6 +138,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         # F-30: optional auto-clear trigger descriptor.
         clear_when = call.data.get(ATTR_CLEAR_WHEN)
         auto_clear_registry = getattr(entry.runtime_data, "auto_clear", None)
+        # F-fork: per-call routing mode (drop-in parity with iq_notify).
+        route_mode = call.data.get(ATTR_MODE)
+        route_window = call.data.get(ATTR_MODE_WINDOW)
 
         # F-27: normalize category input to a de-duplicated list, preserving order.
         if isinstance(category_input, str):
@@ -211,6 +218,8 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 navigate_to=navigate_to,
                 persons=persons,
                 recipients=recipients,
+                route_mode=route_mode,
+                route_window=route_window,
             )
             processed_count += 1
 
@@ -251,6 +260,8 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         navigate_to: str | None,
         persons: list,
         recipients: dict,
+        route_mode: str | None = None,
+        route_window: int | None = None,
     ) -> dict:
         """Dispatch a single notification to one category's subscribers.
 
@@ -266,16 +277,33 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             "dropped": [],
         }
 
-        # Priority fallback (F-fork, ported from iq_notify): a category-level
-        # "only_home_then_away" / "just_left_then_away" mode narrows the
-        # person list to a single winning presence group for this call,
-        # before subscription mode/conditions are evaluated per person.
+        # Presence pre-filter (F-fork, ported from iq_notify): narrow the
+        # person list to a single winning presence group for this call, before
+        # subscription mode/conditions are evaluated per person.
+        #
+        # A per-call route_mode (drop-in parity with iq_notify's send-time
+        # `mode`) takes precedence and overrides the category's static
+        # priority_fallback. An explicit route_mode of "all" bypasses both.
+        # When no route_mode is given, the category-level priority_fallback
+        # ("only_home_then_away" / "just_left_then_away") still applies.
         dispatch_persons = persons
-        priority_fallback = (category or {}).get("priority_fallback")
-        if priority_fallback:
-            dispatch_persons = resolve_priority_group(
-                persons, priority_fallback, dt_util.utcnow(),
+        filter_reason: str | None = None
+        if route_mode == ROUTE_MODE_ALL:
+            pass  # explicit per-call "all" — notify everyone, ignore fallback
+        elif route_mode:
+            dispatch_persons = resolve_mode_group(
+                persons, route_mode, route_window, dt_util.utcnow(),
             )
+            filter_reason = f"Route mode ({route_mode})"
+        else:
+            priority_fallback = (category or {}).get("priority_fallback")
+            if priority_fallback:
+                dispatch_persons = resolve_priority_group(
+                    persons, priority_fallback, dt_util.utcnow(),
+                )
+                filter_reason = f"Priority fallback ({priority_fallback.get('mode')})"
+
+        if filter_reason is not None:
             winning_ids = {p.entity_id for p in dispatch_persons}
             # Disabled users are already silently skipped by the
             # is_user_enabled check below with no log entry; don't log a
@@ -293,10 +321,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     title=title,
                     message=message,
                     outcome=LOG_OUTCOME_SKIPPED,
-                    reason=f"Priority fallback ({priority_fallback.get('mode')}): not in winning group",
+                    reason=f"{filter_reason}: not in winning group",
                     notification_id=notification_id,
                 )
-                delivery_results["dropped"].append(f"{skipped_id}: priority fallback")
+                delivery_results["dropped"].append(
+                    f"{skipped_id}: {filter_reason.lower()}"
+                )
 
         for person_state in dispatch_persons:
             person_id = person_state.entity_id

--- a/custom_components/ticker/services.py
+++ b/custom_components/ticker/services.py
@@ -32,6 +32,7 @@ from .const import (
     MODE_ALWAYS,
     MODE_NEVER,
     MODE_CONDITIONAL,
+    CATEGORY_DEFAULT,
     ROUTE_MODE_ALL,
     LOG_OUTCOME_SKIPPED,
     SMART_TAG_MODE_NONE,
@@ -123,7 +124,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         entry = _get_loaded_entry(hass)
         store = entry.runtime_data.store
 
-        category_input = call.data[ATTR_CATEGORY]
+        category_input = call.data.get(ATTR_CATEGORY, CATEGORY_DEFAULT)
         title = call.data[ATTR_TITLE]
         message = call.data[ATTR_MESSAGE]
         expiration = call.data.get(ATTR_EXPIRATION, DEFAULT_EXPIRATION_HOURS)
@@ -139,8 +140,11 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         clear_when = call.data.get(ATTR_CLEAR_WHEN)
         auto_clear_registry = getattr(entry.runtime_data, "auto_clear", None)
         # F-fork: per-call routing mode (drop-in parity with iq_notify).
-        route_mode = call.data.get(ATTR_MODE)
-        route_window = call.data.get(ATTR_MODE_WINDOW)
+        # Accept mode/mode_window at the top level, or nested in `data`
+        # (iq_notify's convention) as a fallback; pop from base_data so they
+        # are not forwarded verbatim to the underlying notify service.
+        route_mode = call.data.get(ATTR_MODE) or base_data.pop("mode", None)
+        route_window = call.data.get(ATTR_MODE_WINDOW) or base_data.pop("mode_window", None)
 
         # F-27: normalize category input to a de-duplicated list, preserving order.
         if isinstance(category_input, str):

--- a/custom_components/ticker/services.yaml
+++ b/custom_components/ticker/services.yaml
@@ -5,6 +5,41 @@
 notify:
   name: Send notification
   description: Send a notification through Ticker to subscribed users
+  fields:
+    mode:
+      name: Routing mode
+      description: >
+        Per-call presence routing (drop-in parity with iq_notify). Filters
+        recipients by presence for this call, overriding the category's
+        priority fallback. Omit to use the category's own routing.
+      required: false
+      example: only_home_then_away
+      selector:
+        select:
+          options:
+            - all
+            - only_home
+            - only_away
+            - just_arrived
+            - just_left
+            - staying_home
+            - staying_away
+            - only_home_then_away
+            - just_left_then_away
+            - nobody_home
+    mode_window:
+      name: Mode window (minutes)
+      description: >
+        Recency window for the just_*, staying_* and just_left_then_away
+        modes. Defaults to 2 minutes.
+      required: false
+      example: 5
+      selector:
+        number:
+          min: 1
+          max: 1440
+          unit_of_measurement: minutes
+          mode: box
 
 clear_notification:
   name: Clear notification

--- a/custom_components/ticker/store/categories.py
+++ b/custom_components/ticker/store/categories.py
@@ -9,7 +9,14 @@ from typing import TYPE_CHECKING, Any, Callable
 from homeassistant.helpers.storage import Store
 
 from ..conditions_normalize import normalize_conditions_negate
-from ..const import CATEGORY_DEFAULT, CATEGORY_DEFAULT_NAME, SMART_TAG_MODE_NONE
+from ..const import (
+    CATEGORY_DEFAULT,
+    CATEGORY_DEFAULT_NAME,
+    DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES,
+    MAX_PRIORITY_FALLBACK_WINDOW_MINUTES,
+    PRIORITY_FALLBACK_MODES,
+    SMART_TAG_MODE_NONE,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -34,6 +41,31 @@ def _has_active_smart_config(config: dict) -> bool:
     if config.get("persistent"):
         return True
     return False
+
+
+def _normalize_priority_fallback(value: dict | None) -> dict[str, Any] | None:
+    """Normalize a priority_fallback payload to its sparse storage shape.
+
+    Returns None (omit from storage) unless ``mode`` is a recognized
+    fallback mode. ``window_minutes`` defaults to
+    DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES when missing or invalid.
+    """
+    if not value or not isinstance(value, dict):
+        return None
+    mode = value.get("mode")
+    if mode not in PRIORITY_FALLBACK_MODES:
+        return None
+    window = value.get("window_minutes")
+    # `not (0 < window <= MAX)` also catches NaN: any comparison with NaN
+    # is False, so `0 < nan <= MAX` is False and `not False` is True here,
+    # falling back to the default same as any other out-of-range value.
+    if (
+        not isinstance(window, (int, float))
+        or isinstance(window, bool)
+        or not (0 < window <= MAX_PRIORITY_FALLBACK_WINDOW_MINUTES)
+    ):
+        window = DEFAULT_PRIORITY_FALLBACK_WINDOW_MINUTES
+    return {"mode": mode, "window_minutes": int(window)}
 
 
 class CategoryMixin:
@@ -105,6 +137,7 @@ class CategoryMixin:
         android_channel: str | None = None,
         chime_media_content_id: str | None = None,
         volume_override: float | None = None,
+        priority_fallback: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Create a new category.
 
@@ -138,6 +171,12 @@ class CategoryMixin:
                 value is injected as `channel` in the push data payload for Android
                 recipients only. Omitted when None (sparse storage); an empty string
                 clears any existing value. Not injected for iOS (plain format).
+            priority_fallback: Optional dict ``{"mode": ..., "window_minutes": ...}``
+                (ported from iq_notify). "only_home_then_away" notifies only persons
+                currently home, falling back to everyone away when none are home.
+                "just_left_then_away" notifies only persons who left within
+                window_minutes, falling back to everyone away when none just left.
+                Omitted when mode is not recognized (sparse storage).
         """
         category: dict[str, Any] = {
             "id": category_id,
@@ -176,6 +215,10 @@ class CategoryMixin:
             and 0.0 <= float(volume_override) <= 1.0
         ):
             category["volume_override"] = float(volume_override)
+        # Priority fallback (sparse: only persisted when mode is recognized)
+        normalized_priority_fallback = _normalize_priority_fallback(priority_fallback)
+        if normalized_priority_fallback:
+            category["priority_fallback"] = normalized_priority_fallback
         self._categories[category_id] = category
         await self.async_save_categories()
         _LOGGER.info("Created category: %s", category_id)
@@ -200,6 +243,8 @@ class CategoryMixin:
         chime_media_content_id: str | None = None,
         volume_override: float | None = None,
         clear_volume_override: bool = False,
+        priority_fallback: dict[str, Any] | None = None,
+        clear_priority_fallback: bool = False,
     ) -> dict[str, Any] | None:
         """Update an existing category.
 
@@ -220,6 +265,11 @@ class CategoryMixin:
             android_channel: If provided, set the Android notification channel ID.
                 A non-empty string is stored; an empty string clears the key
                 (sparse storage). None leaves the current value unchanged.
+            priority_fallback: If provided (and mode recognized), set the
+                category's priority fallback config. None leaves the current
+                value unchanged; clear_priority_fallback removes it.
+            clear_priority_fallback: If True, explicitly remove
+                priority_fallback from the category dict.
         """
         if category_id not in self._categories:
             return None
@@ -300,6 +350,15 @@ class CategoryMixin:
                 category["volume_override"] = float(volume_override)
             else:
                 category.pop("volume_override", None)
+
+        if clear_priority_fallback:
+            category.pop("priority_fallback", None)
+        elif priority_fallback is not None:
+            normalized_priority_fallback = _normalize_priority_fallback(priority_fallback)
+            if normalized_priority_fallback:
+                category["priority_fallback"] = normalized_priority_fallback
+            else:
+                category.pop("priority_fallback", None)
 
         if clear_defaults:
             category.pop("default_mode", None)

--- a/custom_components/ticker/websocket/categories.py
+++ b/custom_components/ticker/websocket/categories.py
@@ -14,6 +14,8 @@ from ..const import (
     DOMAIN,
     MAX_CHIME_MEDIA_CONTENT_ID_LENGTH,
     MAX_NAVIGATE_TO_LENGTH,
+    MAX_PRIORITY_FALLBACK_WINDOW_MINUTES,
+    PRIORITY_FALLBACK_MODES,
     SMART_TAG_MODES,
     VOLUME_OVERRIDE_MAX,
     VOLUME_OVERRIDE_MIN,
@@ -29,6 +31,13 @@ from .validation import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+PRIORITY_FALLBACK_SCHEMA = vol.Schema({
+    vol.Required("mode"): vol.In(PRIORITY_FALLBACK_MODES),
+    vol.Optional("window_minutes"): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=MAX_PRIORITY_FALLBACK_WINDOW_MINUTES),
+    ),
+})
 
 
 @websocket_api.websocket_command(
@@ -85,6 +94,7 @@ async def ws_get_categories(
                 vol.Range(min=VOLUME_OVERRIDE_MIN, max=VOLUME_OVERRIDE_MAX),
             ),
         ),
+        vol.Optional("priority_fallback"): vol.Any(None, PRIORITY_FALLBACK_SCHEMA),
     }
 )
 @websocket_api.async_response
@@ -176,6 +186,7 @@ async def ws_create_category(
         android_channel=android_channel,
         chime_media_content_id=chime_id,
         volume_override=volume_override,
+        priority_fallback=msg.get("priority_fallback"),
     )
 
     connection.send_result(msg["id"], {"category": category})
@@ -214,6 +225,7 @@ async def ws_create_category(
                 vol.Range(min=VOLUME_OVERRIDE_MIN, max=VOLUME_OVERRIDE_MAX),
             ),
         ),
+        vol.Optional("priority_fallback"): vol.Any(None, PRIORITY_FALLBACK_SCHEMA),
     }
 )
 @websocket_api.async_response
@@ -331,6 +343,18 @@ async def ws_update_category(
             update_kwargs["clear_volume_override"] = True
         else:
             update_kwargs["volume_override"] = volume_value
+
+    # priority_fallback: present with None clears the key, present with a
+    # dict sets it. Voluptuous already validated mode/window_minutes.
+    priority_fallback_present = "priority_fallback" in msg
+    priority_fallback_value = (
+        msg.get("priority_fallback") if priority_fallback_present else None
+    )
+    if priority_fallback_present:
+        if priority_fallback_value is None:
+            update_kwargs["clear_priority_fallback"] = True
+        else:
+            update_kwargs["priority_fallback"] = priority_fallback_value
 
     category = await store.async_update_category(**update_kwargs)
 

--- a/custom_components/ticker/websocket/validation.py
+++ b/custom_components/ticker/websocket/validation.py
@@ -16,8 +16,11 @@ from ..const import (
     CONDITION_NODE_GROUP,
     CONDITION_OPERATORS,
     DOMAIN,
+    DURATION_COMPARISONS,
     MAX_ACTIONS_PER_SET,
+    MAX_DURATION_MINUTES,
     MAX_NAVIGATE_TO_LENGTH,
+    RULE_TYPE_DURATION,
     RULE_TYPE_STATE,
     RULE_TYPE_TIME,
     RULE_TYPE_ZONE,
@@ -277,6 +280,51 @@ def _validate_state_leaf(
     return None
 
 
+def _validate_duration_leaf(
+    leaf: dict,
+    hass: HomeAssistant | None,
+) -> tuple[str, str] | None:
+    """Validate a duration leaf node.
+
+    ``entity_id`` is optional (blank defaults to the subscription's own
+    person entity at evaluation time), but when present must be a valid
+    entity ID and — when ``hass`` is provided — must exist. ``state`` and
+    a positive ``minutes`` (within ``MAX_DURATION_MINUTES``) are required.
+    ``comparison`` defaults to "within" and must be a known value.
+
+    Returns:
+        (error_code, error_message) tuple if invalid, None if valid.
+    """
+    entity_id = leaf.get("entity_id", "")
+    if entity_id:
+        if not re.match(r"^[a-z_]+\.[a-z0-9_]+$", entity_id):
+            return ("invalid_duration_rule", f"Invalid entity ID format '{entity_id}'")
+        if hass is not None and not hass.states.get(entity_id):
+            return ("entity_not_found", f"Entity '{entity_id}' does not exist")
+
+    state_val = leaf.get("state", "")
+    if not isinstance(state_val, str) or not state_val:
+        return ("invalid_duration_rule", "'state' is required for duration rules")
+
+    comparison = leaf.get("comparison", DURATION_COMPARISONS[0])
+    if comparison not in DURATION_COMPARISONS:
+        return (
+            "invalid_duration_rule",
+            f"'comparison' must be one of {DURATION_COMPARISONS}",
+        )
+
+    minutes = leaf.get("minutes")
+    if not isinstance(minutes, (int, float)) or isinstance(minutes, bool) or minutes <= 0:
+        return ("invalid_duration_rule", "'minutes' must be a positive number")
+    if minutes > MAX_DURATION_MINUTES:
+        return (
+            "invalid_duration_rule",
+            f"'minutes' must be {MAX_DURATION_MINUTES} or less",
+        )
+
+    return None
+
+
 def _validate_leaf(
     leaf: dict,
     hass: HomeAssistant | None,
@@ -293,6 +341,8 @@ def _validate_leaf(
         return _validate_time_leaf(leaf)
     if leaf_type == RULE_TYPE_STATE:
         return _validate_state_leaf(leaf, hass)
+    if leaf_type == RULE_TYPE_DURATION:
+        return _validate_duration_leaf(leaf, hass)
     return ("invalid_leaf_type", f"Unknown leaf type '{leaf_type}'")
 
 

--- a/custom_components/ticker/websocket/validation.py
+++ b/custom_components/ticker/websocket/validation.py
@@ -45,6 +45,10 @@ MAX_COLOR_LENGTH = 20
 CATEGORY_ID_PATTERN = re.compile(r"^[a-z0-9_]+$")
 ICON_PATTERN = re.compile(r"^[a-z0-9_\-:]+$", re.IGNORECASE)
 COLOR_PATTERN = re.compile(r"^#[0-9A-Fa-f]{6}$")
+# domain.object_id with safe characters; shared by validate_entity_id (which
+# also checks a specific domain prefix) and any validator that accepts an
+# entity ID from any domain (e.g. duration rule leaves).
+ENTITY_ID_FORMAT_PATTERN = re.compile(r"^[a-z_]+\.[a-z0-9_]+$")
 
 
 def sanitize_for_storage(value: str | None, max_length: int = 200) -> str | None:
@@ -178,7 +182,7 @@ def validate_entity_id(entity_id: str, domain: str) -> tuple[bool, str | None]:
         return False, f"Invalid {domain} entity ID format"
 
     # Basic format check: domain.object_id with safe characters
-    if not re.match(r"^[a-z_]+\.[a-z0-9_]+$", entity_id):
+    if not ENTITY_ID_FORMAT_PATTERN.match(entity_id):
         return False, f"Invalid {domain} entity ID format"
 
     return True, None
@@ -288,7 +292,7 @@ def _validate_duration_leaf(
 
     ``entity_id`` is optional (blank defaults to the subscription's own
     person entity at evaluation time), but when present must be a valid
-    entity ID and — when ``hass`` is provided — must exist. ``state`` and
+    entity ID, and must exist when ``hass`` is provided. ``state`` and
     a positive ``minutes`` (within ``MAX_DURATION_MINUTES``) are required.
     ``comparison`` defaults to "within" and must be a known value.
 
@@ -297,7 +301,7 @@ def _validate_duration_leaf(
     """
     entity_id = leaf.get("entity_id", "")
     if entity_id:
-        if not re.match(r"^[a-z_]+\.[a-z0-9_]+$", entity_id):
+        if not ENTITY_ID_FORMAT_PATTERN.match(entity_id):
             return ("invalid_duration_rule", f"Invalid entity ID format '{entity_id}'")
         if hass is not None and not hass.states.get(entity_id):
             return ("entity_not_found", f"Entity '{entity_id}' does not exist")

--- a/tests/test_duration_listener_scheduling.py
+++ b/tests/test_duration_listener_scheduling.py
@@ -143,6 +143,54 @@ async def test_blank_entity_id_resolves_to_person_id_for_scheduling():
 
 
 @pytest.mark.asyncio
+async def test_blank_entity_id_duration_leaf_registers_person_entity_listener():
+    """Regression: the documented default (blank entity_id = subscriber's
+    person) must get an entity-change listener, for both comparisons --
+    otherwise the person transitioning state is never noticed at all."""
+    person = _person_state("person.x", "not_home", minutes_ago=1, now=_NOW)
+    hass = _make_hass({"person.x": person})
+    store = _make_store({
+        "person.x:cat1": _duration_sub(
+            "person.x", "cat1", entity_id="", minutes=10, comparison="within",
+        ),
+    })
+    mgr = ConditionListenerManager(hass, store)
+
+    with patch(
+        "custom_components.ticker.condition_listeners.dt_util.utcnow",
+        return_value=_NOW,
+    ), patch(
+        "custom_components.ticker.condition_listeners.async_call_later",
+    ):
+        await mgr.async_refresh_listeners()
+
+    assert "person.x" in mgr._tracked_entities
+
+
+@pytest.mark.asyncio
+async def test_entity_reevaluation_reschedules_duration_wakeup():
+    """Regression: an entity transitioning into a duration leaf's target
+    state must (re)compute the for_at_least wakeup immediately, not only
+    on the next unrelated subscription-change refresh."""
+    person = _person_state("person.x", "home", minutes_ago=0, now=_NOW)
+    hass = _make_hass({"person.x": person})
+    store = _make_store({
+        "person.x:cat1": _duration_sub("person.x", "cat1", "person.x", minutes=15),
+    })
+    mgr = ConditionListenerManager(hass, store)
+
+    with patch(
+        "custom_components.ticker.condition_listeners.dt_util.utcnow",
+        return_value=_NOW,
+    ), patch(
+        "custom_components.ticker.condition_listeners.async_call_later",
+    ) as mock_call_later:
+        await mgr._async_reevaluate_for_entity("person.x")
+
+    assert mock_call_later.called
+
+
+@pytest.mark.asyncio
 async def test_stale_wakeup_cancelled_when_no_duration_leaves_pending():
     """A previously scheduled wakeup is cancelled once nothing needs it."""
     hass = _make_hass({})

--- a/tests/test_duration_listener_scheduling.py
+++ b/tests/test_duration_listener_scheduling.py
@@ -1,0 +1,161 @@
+"""Tests for duration rule wakeup scheduling in ConditionListenerManager.
+
+A "for_at_least" duration leaf becomes true at a fixed future timestamp
+with no state-change event to trigger re-evaluation, so the manager must
+schedule a one-shot timer for the earliest such threshold and reschedule
+on every listener refresh. Covers:
+
+- async_refresh_listeners schedules a wakeup when a pending for_at_least
+  leaf is below its threshold
+- no wakeup is scheduled once the threshold has already passed
+- blank entity_id resolves to the subscription's person_id for scheduling
+- a stale wakeup timer is cancelled when no duration leaves remain pending
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.ticker.condition_listeners import ConditionListenerManager
+
+
+def _make_hass(states: dict[str, MagicMock] | None = None) -> MagicMock:
+    hass = MagicMock()
+    hass.is_running = True
+    states = states or {}
+    hass.states.get = lambda eid: states.get(eid)
+    return hass
+
+
+def _make_store(subscriptions: dict) -> MagicMock:
+    store = MagicMock()
+    store.get_all_subscriptions.return_value = subscriptions
+    store.get_queue_for_person.return_value = []
+    store.is_user_enabled.return_value = True
+    return store
+
+
+def _duration_sub(
+    person_id: str,
+    category_id: str,
+    entity_id: str,
+    minutes: int,
+    comparison: str = "for_at_least",
+) -> dict:
+    return {
+        "person_id": person_id,
+        "category_id": category_id,
+        "mode": "conditional",
+        "conditions": {
+            "queue_until_met": True,
+            "condition_tree": {
+                "type": "group",
+                "operator": "AND",
+                "children": [{
+                    "type": "duration",
+                    "entity_id": entity_id,
+                    "state": "home",
+                    "comparison": comparison,
+                    "minutes": minutes,
+                }],
+            },
+        },
+    }
+
+
+def _person_state(entity_id: str, state: str, minutes_ago: float, now: datetime) -> MagicMock:
+    s = MagicMock()
+    s.entity_id = entity_id
+    s.state = state
+    s.last_changed = now - timedelta(minutes=minutes_ago)
+    return s
+
+
+_NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_schedules_wakeup_for_pending_for_at_least_leaf():
+    """Person home 5m, threshold 15m -> wakeup scheduled ~10m out."""
+    person = _person_state("person.x", "home", minutes_ago=5, now=_NOW)
+    hass = _make_hass({"person.x": person})
+    store = _make_store({
+        "person.x:cat1": _duration_sub("person.x", "cat1", "person.x", minutes=15),
+    })
+    mgr = ConditionListenerManager(hass, store)
+
+    with patch(
+        "custom_components.ticker.condition_listeners.dt_util.utcnow",
+        return_value=_NOW,
+    ), patch(
+        "custom_components.ticker.condition_listeners.async_call_later",
+    ) as mock_call_later:
+        await mgr.async_refresh_listeners()
+
+    assert mock_call_later.called
+    _hass_arg, delay, _cb = mock_call_later.call_args[0]
+    assert 590 <= delay <= 600  # ~10 minutes remaining
+
+
+@pytest.mark.asyncio
+async def test_no_wakeup_when_threshold_already_passed():
+    """Person home 30m, threshold 15m -> already met, no future wakeup needed."""
+    person = _person_state("person.x", "home", minutes_ago=30, now=_NOW)
+    hass = _make_hass({"person.x": person})
+    store = _make_store({
+        "person.x:cat1": _duration_sub("person.x", "cat1", "person.x", minutes=15),
+    })
+    mgr = ConditionListenerManager(hass, store)
+
+    with patch(
+        "custom_components.ticker.condition_listeners.dt_util.utcnow",
+        return_value=_NOW,
+    ), patch(
+        "custom_components.ticker.condition_listeners.async_call_later",
+    ) as mock_call_later:
+        await mgr.async_refresh_listeners()
+
+    assert not mock_call_later.called
+
+
+@pytest.mark.asyncio
+async def test_blank_entity_id_resolves_to_person_id_for_scheduling():
+    """Duration leaf with no entity_id defaults to the subscription's person."""
+    person = _person_state("person.x", "home", minutes_ago=1, now=_NOW)
+    hass = _make_hass({"person.x": person})
+    store = _make_store({
+        "person.x:cat1": _duration_sub("person.x", "cat1", "", minutes=10),
+    })
+    mgr = ConditionListenerManager(hass, store)
+
+    with patch(
+        "custom_components.ticker.condition_listeners.dt_util.utcnow",
+        return_value=_NOW,
+    ), patch(
+        "custom_components.ticker.condition_listeners.async_call_later",
+    ) as mock_call_later:
+        await mgr.async_refresh_listeners()
+
+    assert mock_call_later.called
+
+
+@pytest.mark.asyncio
+async def test_stale_wakeup_cancelled_when_no_duration_leaves_pending():
+    """A previously scheduled wakeup is cancelled once nothing needs it."""
+    hass = _make_hass({})
+    store = _make_store({})
+    mgr = ConditionListenerManager(hass, store)
+
+    stale_unsub = MagicMock()
+    mgr._duration_wakeup_unsub = stale_unsub
+
+    with patch(
+        "custom_components.ticker.condition_listeners.async_call_later",
+    ):
+        await mgr.async_refresh_listeners()
+
+    stale_unsub.assert_called_once()
+    assert mgr._duration_wakeup_unsub is None

--- a/tests/test_duration_rule.py
+++ b/tests/test_duration_rule.py
@@ -1,0 +1,291 @@
+"""Tests for the duration rule type (F-fork: Duration Rule Type).
+
+Covers:
+- evaluate_duration_rule: within / for_at_least comparisons, entity
+  default-to-person, missing fields, entity not found
+- evaluate_rule dispatch to RULE_TYPE_DURATION
+- _collect_triggers_from_node / get_queue_triggers collecting duration leaves
+- validate_condition_tree accepting/rejecting duration leaves
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from custom_components.ticker.conditions import (
+    evaluate_duration_rule,
+    evaluate_rule,
+    get_queue_triggers,
+)
+from custom_components.ticker.websocket.validation import validate_condition_tree
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = MagicMock()
+
+
+def _now():
+    """A fixed reference 'now' for deterministic elapsed-time math."""
+    from datetime import datetime, timezone
+
+    return datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _state(entity_id: str, state: str, minutes_ago: float) -> MagicMock:
+    s = MagicMock()
+    s.entity_id = entity_id
+    s.state = state
+    s.last_changed = _now() - timedelta(minutes=minutes_ago)
+    return s
+
+
+def _hass_with_state(state: MagicMock | None) -> MagicMock:
+    hass = MagicMock()
+    hass.states.get = lambda eid: state if state and eid == state.entity_id else None
+    return hass
+
+
+def _duration_leaf(**overrides) -> dict:
+    leaf = {
+        "type": "duration",
+        "entity_id": "person.frank",
+        "state": "home",
+        "comparison": "within",
+        "minutes": 10,
+    }
+    leaf.update(overrides)
+    return leaf
+
+
+# ---------------------------------------------------------------------------
+# evaluate_duration_rule: "within" comparison (just_arrived / just_left)
+# ---------------------------------------------------------------------------
+
+class TestDurationWithin:
+    def test_within_threshold_is_met(self):
+        state = _state("person.frank", "home", minutes_ago=5)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="within", minutes=10)
+        is_met, reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is True
+        assert "person.frank" in reason
+
+    def test_beyond_threshold_is_not_met(self):
+        state = _state("person.frank", "home", minutes_ago=15)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="within", minutes=10)
+        is_met, _reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+
+    def test_exact_threshold_is_met_inclusive(self):
+        state = _state("person.frank", "home", minutes_ago=10)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="within", minutes=10)
+        is_met, _reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is True
+
+    def test_wrong_state_is_not_met(self):
+        state = _state("person.frank", "not_home", minutes_ago=1)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="within", minutes=10, state="home")
+        is_met, reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+        assert "not_home" in reason
+
+
+# ---------------------------------------------------------------------------
+# evaluate_duration_rule: "for_at_least" comparison (staying_home / staying_away)
+# ---------------------------------------------------------------------------
+
+class TestDurationForAtLeast:
+    def test_long_enough_is_met(self):
+        state = _state("person.frank", "home", minutes_ago=30)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="for_at_least", minutes=15)
+        is_met, _reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is True
+
+    def test_not_long_enough_is_not_met(self):
+        state = _state("person.frank", "home", minutes_ago=5)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="for_at_least", minutes=15)
+        is_met, _reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+
+    def test_exact_threshold_is_met_inclusive(self):
+        state = _state("person.frank", "home", minutes_ago=15)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="for_at_least", minutes=15)
+        is_met, _reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is True
+
+
+# ---------------------------------------------------------------------------
+# entity_id defaulting to person_state, and missing-field handling
+# ---------------------------------------------------------------------------
+
+class TestDurationDefaultsAndErrors:
+    def test_blank_entity_id_defaults_to_person_state(self):
+        state = _state("person.kevin", "home", minutes_ago=2)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(entity_id="", comparison="within", minutes=10)
+        is_met, reason = evaluate_duration_rule(hass, rule, state, now=_now())
+        assert is_met is True
+        assert "person.kevin" in reason
+
+    def test_blank_entity_id_no_person_state_is_not_met(self):
+        hass = _hass_with_state(None)
+        rule = _duration_leaf(entity_id="", comparison="within", minutes=10)
+        is_met, reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+        assert "entity_id" in reason
+
+    def test_missing_state_field(self):
+        hass = _hass_with_state(_state("person.frank", "home", 1))
+        rule = _duration_leaf(state="")
+        is_met, reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+        assert "state" in reason
+
+    def test_missing_minutes(self):
+        hass = _hass_with_state(_state("person.frank", "home", 1))
+        rule = _duration_leaf(minutes=None)
+        is_met, reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+        assert "minutes" in reason
+
+    def test_negative_minutes(self):
+        hass = _hass_with_state(_state("person.frank", "home", 1))
+        rule = _duration_leaf(minutes=-5)
+        is_met, _reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+
+    def test_entity_not_found(self):
+        hass = _hass_with_state(None)
+        rule = _duration_leaf(entity_id="person.ghost")
+        is_met, reason = evaluate_duration_rule(hass, rule, None, now=_now())
+        assert is_met is False
+        assert "not found" in reason
+
+
+# ---------------------------------------------------------------------------
+# evaluate_rule dispatch
+# ---------------------------------------------------------------------------
+
+class TestEvaluateRuleDispatchesDuration:
+    def test_dispatches_to_duration_evaluator(self):
+        state = _state("person.frank", "home", minutes_ago=5)
+        hass = _hass_with_state(state)
+        rule = _duration_leaf(comparison="within", minutes=10)
+        is_met, _reason = evaluate_rule(hass, rule, None, now=_now())
+        assert is_met is True
+
+
+# ---------------------------------------------------------------------------
+# Trigger collection for the condition-listener scheduler
+# ---------------------------------------------------------------------------
+
+class TestDurationTriggerCollection:
+    def test_get_queue_triggers_collects_duration_entity_and_meta(self):
+        conditions = {
+            "queue_until_met": True,
+            "condition_tree": {
+                "type": "group",
+                "operator": "AND",
+                "children": [_duration_leaf(entity_id="person.frank")],
+            },
+        }
+        triggers = get_queue_triggers(conditions)
+        assert "person.frank" in triggers["entities"]
+        assert len(triggers["durations"]) == 1
+        assert triggers["durations"][0]["entity_id"] == "person.frank"
+        assert triggers["durations"][0]["comparison"] == "within"
+
+    def test_get_queue_triggers_collects_blank_entity_duration(self):
+        """Blank entity_id is still collected; caller resolves the person default."""
+        conditions = {
+            "queue_until_met": True,
+            "condition_tree": {
+                "type": "group",
+                "operator": "AND",
+                "children": [_duration_leaf(entity_id="")],
+            },
+        }
+        triggers = get_queue_triggers(conditions)
+        assert triggers["entities"] == set() or "" not in triggers["entities"]
+        assert len(triggers["durations"]) == 1
+        assert triggers["durations"][0]["entity_id"] == ""
+
+    def test_get_queue_triggers_empty_when_queue_not_enabled(self):
+        conditions = {
+            "queue_until_met": False,
+            "condition_tree": {
+                "type": "group",
+                "operator": "AND",
+                "children": [_duration_leaf()],
+            },
+        }
+        triggers = get_queue_triggers(conditions)
+        assert triggers["durations"] == []
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class TestDurationValidation:
+    def _group(self, *children):
+        return {"type": "group", "operator": "AND", "children": list(children)}
+
+    def test_valid_duration_leaf_passes(self):
+        tree = self._group(_duration_leaf())
+        assert validate_condition_tree(tree) is None
+
+    def test_blank_entity_id_is_valid_structurally(self):
+        tree = self._group(_duration_leaf(entity_id=""))
+        assert validate_condition_tree(tree) is None
+
+    def test_invalid_entity_id_format_rejected(self):
+        tree = self._group(_duration_leaf(entity_id="not-a-valid-id"))
+        error = validate_condition_tree(tree)
+        assert error is not None
+        assert error[0] == "invalid_duration_rule"
+
+    def test_entity_not_found_rejected_when_hass_provided(self):
+        hass = _hass_with_state(None)
+        tree = self._group(_duration_leaf(entity_id="person.ghost"))
+        error = validate_condition_tree(tree, hass)
+        assert error is not None
+        assert error[0] == "entity_not_found"
+
+    def test_missing_state_rejected(self):
+        tree = self._group(_duration_leaf(state=""))
+        error = validate_condition_tree(tree)
+        assert error is not None
+        assert error[0] == "invalid_duration_rule"
+
+    def test_invalid_comparison_rejected(self):
+        tree = self._group(_duration_leaf(comparison="sideways"))
+        error = validate_condition_tree(tree)
+        assert error is not None
+        assert error[0] == "invalid_duration_rule"
+
+    def test_zero_minutes_rejected(self):
+        tree = self._group(_duration_leaf(minutes=0))
+        error = validate_condition_tree(tree)
+        assert error is not None
+
+    def test_excessive_minutes_rejected(self):
+        tree = self._group(_duration_leaf(minutes=99999))
+        error = validate_condition_tree(tree)
+        assert error is not None
+        assert error[0] == "invalid_duration_rule"
+
+    def test_non_numeric_minutes_rejected(self):
+        tree = self._group(_duration_leaf(minutes="ten"))
+        error = validate_condition_tree(tree)
+        assert error is not None

--- a/tests/test_duration_rule.py
+++ b/tests/test_duration_rule.py
@@ -25,9 +25,6 @@ from custom_components.ticker.websocket.validation import validate_condition_tre
 # Helpers
 # ---------------------------------------------------------------------------
 
-_NOW = MagicMock()
-
-
 def _now():
     """A fixed reference 'now' for deterministic elapsed-time math."""
     from datetime import datetime, timezone
@@ -137,12 +134,15 @@ class TestDurationDefaultsAndErrors:
         assert is_met is True
         assert "person.kevin" in reason
 
-    def test_blank_entity_id_no_person_state_is_not_met(self):
+    def test_blank_entity_id_no_person_state_is_skipped_as_met(self):
+        """Recipients have no person_state; a blank-entity duration leaf must
+        not become permanently unmet with no way to fix it (mirrors the
+        zone rule's "no person context" skip for recipients)."""
         hass = _hass_with_state(None)
         rule = _duration_leaf(entity_id="", comparison="within", minutes=10)
         is_met, reason = evaluate_duration_rule(hass, rule, None, now=_now())
-        assert is_met is False
-        assert "entity_id" in reason
+        assert is_met is True
+        assert "skipped" in reason
 
     def test_missing_state_field(self):
         hass = _hass_with_state(_state("person.frank", "home", 1))

--- a/tests/test_mode_routing.py
+++ b/tests/test_mode_routing.py
@@ -1,0 +1,155 @@
+"""Tests for per-call routing modes (F-fork, drop-in parity with iq_notify).
+
+Covers mode_routing.resolve_mode_group across the full iq_notify mode set,
+including presence classification, recency windows, unresolved-state
+exclusion, and delegation to resolve_priority_group for the two "then_away"
+modes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from custom_components.ticker.mode_routing import resolve_mode_group
+
+
+_NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _Person:
+    """Minimal person State stand-in (entity_id, state, last_changed)."""
+
+    def __init__(self, entity_id: str, state: str, minutes_ago: float = 60) -> None:
+        self.entity_id = entity_id
+        self.state = state
+        self.last_changed = _NOW - timedelta(minutes=minutes_ago)
+        self.attributes = {"friendly_name": entity_id}
+
+
+def _ids(persons) -> set:
+    return {p.entity_id for p in persons}
+
+
+# ---------------------------------------------------------------------------
+# passthrough / unknown modes
+# ---------------------------------------------------------------------------
+
+class TestPassthrough:
+    def test_none_returns_all(self):
+        ps = [_Person("person.a", "home"), _Person("person.b", "not_home")]
+        assert resolve_mode_group(ps, None, None, _NOW) is ps
+
+    def test_all_returns_all(self):
+        ps = [_Person("person.a", "home"), _Person("person.b", "not_home")]
+        assert resolve_mode_group(ps, "all", None, _NOW) is ps
+
+    def test_unknown_mode_fails_open_to_all(self):
+        ps = [_Person("person.a", "home")]
+        assert resolve_mode_group(ps, "sideways", None, _NOW) == ps
+
+
+# ---------------------------------------------------------------------------
+# static presence modes
+# ---------------------------------------------------------------------------
+
+class TestStaticPresence:
+    def _fixture(self):
+        return [
+            _Person("person.home", "home"),
+            _Person("person.away", "not_home"),
+            _Person("person.unknown", "unknown"),
+            _Person("person.unavail", "unavailable"),
+        ]
+
+    def test_only_home(self):
+        assert _ids(resolve_mode_group(self._fixture(), "only_home", None, _NOW)) == {
+            "person.home"
+        }
+
+    def test_only_away_excludes_unresolved(self):
+        # not_home counts as away; unknown/unavailable are never classified.
+        assert _ids(resolve_mode_group(self._fixture(), "only_away", None, _NOW)) == {
+            "person.away"
+        }
+
+    def test_nobody_home_suppresses_when_someone_home(self):
+        assert resolve_mode_group(self._fixture(), "nobody_home", None, _NOW) == []
+
+    def test_nobody_home_notifies_known_when_no_one_home(self):
+        ps = [
+            _Person("person.away", "not_home"),
+            _Person("person.work", "work"),
+            _Person("person.unknown", "unknown"),
+        ]
+        assert _ids(resolve_mode_group(ps, "nobody_home", None, _NOW)) == {
+            "person.away",
+            "person.work",
+        }
+
+
+# ---------------------------------------------------------------------------
+# recency-window modes
+# ---------------------------------------------------------------------------
+
+class TestRecencyWindows:
+    def _fixture(self):
+        return [
+            _Person("person.home_recent", "home", minutes_ago=1),
+            _Person("person.home_old", "home", minutes_ago=30),
+            _Person("person.away_recent", "not_home", minutes_ago=1),
+            _Person("person.away_old", "not_home", minutes_ago=30),
+        ]
+
+    def test_just_arrived(self):
+        assert _ids(resolve_mode_group(self._fixture(), "just_arrived", 2, _NOW)) == {
+            "person.home_recent"
+        }
+
+    def test_just_left(self):
+        assert _ids(resolve_mode_group(self._fixture(), "just_left", 2, _NOW)) == {
+            "person.away_recent"
+        }
+
+    def test_staying_home(self):
+        assert _ids(resolve_mode_group(self._fixture(), "staying_home", 2, _NOW)) == {
+            "person.home_old"
+        }
+
+    def test_staying_away(self):
+        assert _ids(resolve_mode_group(self._fixture(), "staying_away", 2, _NOW)) == {
+            "person.away_old"
+        }
+
+    def test_window_defaults_on_garbage(self):
+        # None window falls back to default (2 min); home_recent (1m) is in,
+        # home_old (30m) is out.
+        assert _ids(resolve_mode_group(self._fixture(), "just_arrived", None, _NOW)) == {
+            "person.home_recent"
+        }
+
+
+# ---------------------------------------------------------------------------
+# then_away delegation
+# ---------------------------------------------------------------------------
+
+class TestThenAwayDelegation:
+    def test_only_home_then_away_prefers_home(self):
+        ps = [_Person("person.a", "home"), _Person("person.b", "not_home")]
+        assert _ids(
+            resolve_mode_group(ps, "only_home_then_away", None, _NOW)
+        ) == {"person.a"}
+
+    def test_only_home_then_away_falls_back_to_away(self):
+        ps = [_Person("person.a", "not_home"), _Person("person.b", "work")]
+        assert _ids(
+            resolve_mode_group(ps, "only_home_then_away", None, _NOW)
+        ) == {"person.a", "person.b"}
+
+    def test_just_left_then_away_prefers_recent_leavers(self):
+        ps = [
+            _Person("person.recent", "not_home", minutes_ago=1),
+            _Person("person.old", "not_home", minutes_ago=30),
+        ]
+        assert _ids(
+            resolve_mode_group(ps, "just_left_then_away", 2, _NOW)
+        ) == {"person.recent"}

--- a/tests/test_priority_fallback.py
+++ b/tests/test_priority_fallback.py
@@ -1,0 +1,386 @@
+"""Tests for category-level priority fallback (F-fork, ported from iq_notify).
+
+Covers:
+- store/categories.py: sparse persist/normalize of priority_fallback
+- services._resolve_priority_group: only_home_then_away / just_left_then_away
+- services._dispatch_to_category: winning group is what actually gets
+  notified, losing persons are logged as skipped
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.ticker.priority_fallback import resolve_priority_group as _resolve_priority_group
+from custom_components.ticker.store.categories import _normalize_priority_fallback
+
+
+_NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _person(entity_id: str, state: str, minutes_ago: float = 0) -> MagicMock:
+    p = MagicMock()
+    p.entity_id = entity_id
+    p.state = state
+    p.last_changed = _NOW - timedelta(minutes=minutes_ago)
+    p.attributes = {"friendly_name": entity_id}
+    return p
+
+
+# ---------------------------------------------------------------------------
+# store normalization
+# ---------------------------------------------------------------------------
+
+class TestNormalizePriorityFallback:
+    def test_valid_mode_normalizes_with_default_window(self):
+        result = _normalize_priority_fallback({"mode": "only_home_then_away"})
+        assert result == {"mode": "only_home_then_away", "window_minutes": 2}
+
+    def test_valid_mode_with_explicit_window(self):
+        result = _normalize_priority_fallback({
+            "mode": "just_left_then_away", "window_minutes": 10,
+        })
+        assert result == {"mode": "just_left_then_away", "window_minutes": 10}
+
+    def test_unknown_mode_returns_none(self):
+        assert _normalize_priority_fallback({"mode": "sideways"}) is None
+
+    def test_none_returns_none(self):
+        assert _normalize_priority_fallback(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert _normalize_priority_fallback({}) is None
+
+    def test_invalid_window_falls_back_to_default(self):
+        result = _normalize_priority_fallback({
+            "mode": "only_home_then_away", "window_minutes": -5,
+        })
+        assert result["window_minutes"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _resolve_priority_group: only_home_then_away
+# ---------------------------------------------------------------------------
+
+class TestOnlyHomeThenAway:
+    def test_home_persons_win_when_present(self):
+        persons = [
+            _person("person.frank", "home"),
+            _person("person.kevin", "not_home"),
+        ]
+        winners = _resolve_priority_group(
+            persons, {"mode": "only_home_then_away"}, _NOW,
+        )
+        assert [p.entity_id for p in winners] == ["person.frank"]
+
+    def test_falls_back_to_everyone_away_when_nobody_home(self):
+        persons = [
+            _person("person.frank", "not_home"),
+            _person("person.kevin", "not_home"),
+        ]
+        winners = _resolve_priority_group(
+            persons, {"mode": "only_home_then_away"}, _NOW,
+        )
+        assert {p.entity_id for p in winners} == {"person.frank", "person.kevin"}
+
+    def test_empty_persons_list(self):
+        winners = _resolve_priority_group([], {"mode": "only_home_then_away"}, _NOW)
+        assert winners == []
+
+
+# ---------------------------------------------------------------------------
+# _resolve_priority_group: just_left_then_away
+# ---------------------------------------------------------------------------
+
+class TestJustLeftThenAway:
+    def test_recently_left_persons_win(self):
+        persons = [
+            _person("person.frank", "home"),
+            _person("person.kevin", "not_home", minutes_ago=1),
+            _person("person.caroline", "not_home", minutes_ago=30),
+        ]
+        winners = _resolve_priority_group(
+            persons,
+            {"mode": "just_left_then_away", "window_minutes": 5},
+            _NOW,
+        )
+        assert [p.entity_id for p in winners] == ["person.kevin"]
+
+    def test_falls_back_to_everyone_away_when_nobody_just_left(self):
+        persons = [
+            _person("person.frank", "home"),
+            _person("person.kevin", "not_home", minutes_ago=30),
+        ]
+        winners = _resolve_priority_group(
+            persons,
+            {"mode": "just_left_then_away", "window_minutes": 5},
+            _NOW,
+        )
+        assert [p.entity_id for p in winners] == ["person.kevin"]
+
+    def test_home_persons_never_win(self):
+        persons = [_person("person.frank", "home", minutes_ago=1)]
+        winners = _resolve_priority_group(
+            persons,
+            {"mode": "just_left_then_away", "window_minutes": 5},
+            _NOW,
+        )
+        assert winners == []
+
+    def test_default_window_used_when_omitted(self):
+        persons = [_person("person.kevin", "not_home", minutes_ago=1)]
+        winners = _resolve_priority_group(
+            persons, {"mode": "just_left_then_away"}, _NOW,
+        )
+        assert [p.entity_id for p in winners] == ["person.kevin"]
+
+
+class TestUnknownMode:
+    def test_unknown_mode_returns_all_persons_unchanged(self):
+        persons = [_person("person.frank", "home"), _person("person.kevin", "not_home")]
+        winners = _resolve_priority_group(persons, {"mode": "sideways"}, _NOW)
+        assert winners is persons
+
+
+# ---------------------------------------------------------------------------
+# Unresolved presence (unknown/unavailable) excluded from both groups
+# ---------------------------------------------------------------------------
+
+class TestUnresolvedPresenceExcluded:
+    def test_unknown_state_excluded_from_only_home_then_away(self):
+        persons = [
+            _person("person.frank", "home"),
+            _person("person.kevin", "unknown"),
+        ]
+        winners = _resolve_priority_group(
+            persons, {"mode": "only_home_then_away"}, _NOW,
+        )
+        assert [p.entity_id for p in winners] == ["person.frank"]
+
+    def test_unavailable_state_not_selected_as_away_fallback(self):
+        """Nobody home and the only other person is unavailable: fallback
+        must not guess that unavailable == away."""
+        persons = [
+            _person("person.frank", "not_home"),
+            _person("person.kevin", "unavailable"),
+        ]
+        winners = _resolve_priority_group(
+            persons, {"mode": "only_home_then_away"}, _NOW,
+        )
+        assert [p.entity_id for p in winners] == ["person.frank"]
+
+    def test_unknown_state_excluded_from_just_left_then_away(self):
+        persons = [
+            _person("person.kevin", "unknown", minutes_ago=1),
+            _person("person.caroline", "not_home", minutes_ago=1),
+        ]
+        winners = _resolve_priority_group(
+            persons,
+            {"mode": "just_left_then_away", "window_minutes": 5},
+            _NOW,
+        )
+        assert [p.entity_id for p in winners] == ["person.caroline"]
+
+
+# ---------------------------------------------------------------------------
+# Store-layer window_minutes guards (NaN, out-of-range)
+# ---------------------------------------------------------------------------
+
+class TestNormalizePriorityFallbackWindowGuards:
+    def test_nan_window_falls_back_to_default(self):
+        result = _normalize_priority_fallback({
+            "mode": "only_home_then_away", "window_minutes": float("nan"),
+        })
+        assert result["window_minutes"] == 2
+
+    def test_excessive_window_falls_back_to_default(self):
+        result = _normalize_priority_fallback({
+            "mode": "only_home_then_away", "window_minutes": 999999,
+        })
+        assert result["window_minutes"] == 2
+
+    def test_max_window_is_accepted(self):
+        result = _normalize_priority_fallback({
+            "mode": "only_home_then_away", "window_minutes": 1440,
+        })
+        assert result["window_minutes"] == 1440
+
+
+# ---------------------------------------------------------------------------
+# Dispatch integration: winning group is notified, losers are logged skipped
+# ---------------------------------------------------------------------------
+
+
+def _make_hass(persons):
+    hass = MagicMock()
+    hass.services = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.services.async_register = MagicMock()
+    hass.states = MagicMock()
+    hass.states.async_all.return_value = persons
+    hass.states.get = lambda eid: next((p for p in persons if p.entity_id == eid), None)
+    return hass
+
+
+def _make_store(category: dict):
+    store = MagicMock()
+    store.get_recipients.return_value = {}
+    store.category_exists.side_effect = lambda cid: cid == category["id"]
+    store.get_categories.return_value = {category["id"]: category}
+    store.get_category.side_effect = (
+        lambda cid: category if cid == category["id"] else None
+    )
+    store.is_user_enabled.return_value = True
+    store.get_subscription_mode.return_value = "always"
+    store.async_add_log = AsyncMock()
+    return store
+
+
+def _patch_entry(store):
+    entry = MagicMock()
+    entry.runtime_data.store = store
+    entry.runtime_data.auto_clear = None
+    return patch(
+        "custom_components.ticker.services._get_loaded_entry",
+        return_value=entry,
+    )
+
+
+async def _get_handler(hass):
+    from custom_components.ticker.services import async_setup_services
+
+    await async_setup_services(hass)
+    return hass.services.async_register.call_args_list[0][0][2]
+
+
+def _make_call(category):
+    call = MagicMock()
+    call.data = {"category": category, "title": "T", "message": "M"}
+    return call
+
+
+class TestDispatchAppliesPriorityFallback:
+    @pytest.mark.asyncio
+    @patch("custom_components.ticker.services.get_category_sensor", return_value=None)
+    async def test_only_home_person_is_notified_other_is_skipped(self, _sensor):
+        category = {
+            "id": "alerts",
+            "priority_fallback": {"mode": "only_home_then_away", "window_minutes": 2},
+        }
+        persons = [
+            _person("person.frank", "home"),
+            _person("person.kevin", "not_home"),
+        ]
+        hass = _make_hass(persons)
+        store = _make_store(category)
+        handler = await _get_handler(hass)
+
+        with _patch_entry(store), patch(
+            "custom_components.ticker.services.async_send_notification",
+            new_callable=AsyncMock,
+        ) as mock_send, patch(
+            "custom_components.ticker.services.build_smart_tag",
+            return_value=None,
+        ):
+            mock_send.return_value = {"delivered": [], "queued": [], "dropped": []}
+            await handler(_make_call("alerts"))
+
+        assert mock_send.await_count == 1
+        assert mock_send.call_args.args[2] == "person.frank"
+
+        skipped_calls = [
+            c for c in store.async_add_log.call_args_list
+            if c.kwargs.get("person_id") == "person.kevin"
+        ]
+        assert len(skipped_calls) == 1
+        assert "Priority fallback" in skipped_calls[0].kwargs["reason"]
+
+    @pytest.mark.asyncio
+    @patch("custom_components.ticker.services.get_category_sensor", return_value=None)
+    async def test_nobody_home_notifies_everyone_away(self, _sensor):
+        category = {
+            "id": "alerts",
+            "priority_fallback": {"mode": "only_home_then_away", "window_minutes": 2},
+        }
+        persons = [
+            _person("person.frank", "not_home"),
+            _person("person.kevin", "not_home"),
+        ]
+        hass = _make_hass(persons)
+        store = _make_store(category)
+        handler = await _get_handler(hass)
+
+        with _patch_entry(store), patch(
+            "custom_components.ticker.services.async_send_notification",
+            new_callable=AsyncMock,
+        ) as mock_send, patch(
+            "custom_components.ticker.services.build_smart_tag",
+            return_value=None,
+        ):
+            mock_send.return_value = {"delivered": [], "queued": [], "dropped": []}
+            await handler(_make_call("alerts"))
+
+        assert mock_send.await_count == 2
+
+    @pytest.mark.asyncio
+    @patch("custom_components.ticker.services.get_category_sensor", return_value=None)
+    async def test_disabled_user_not_double_logged_as_priority_skip(self, _sensor):
+        """Regression: a globally-disabled user losing the priority group
+        must not get a misleading 'not in winning group' log entry on top
+        of their existing silent is_user_enabled skip."""
+        category = {
+            "id": "alerts",
+            "priority_fallback": {"mode": "only_home_then_away", "window_minutes": 2},
+        }
+        persons = [
+            _person("person.frank", "home"),
+            _person("person.kevin", "not_home"),
+        ]
+        hass = _make_hass(persons)
+        store = _make_store(category)
+        store.is_user_enabled.side_effect = lambda pid: pid != "person.kevin"
+        handler = await _get_handler(hass)
+
+        with _patch_entry(store), patch(
+            "custom_components.ticker.services.async_send_notification",
+            new_callable=AsyncMock,
+        ) as mock_send, patch(
+            "custom_components.ticker.services.build_smart_tag",
+            return_value=None,
+        ):
+            mock_send.return_value = {"delivered": [], "queued": [], "dropped": []}
+            await handler(_make_call("alerts"))
+
+        kevin_logs = [
+            c for c in store.async_add_log.call_args_list
+            if c.kwargs.get("person_id") == "person.kevin"
+        ]
+        assert kevin_logs == []
+
+    @pytest.mark.asyncio
+    @patch("custom_components.ticker.services.get_category_sensor", return_value=None)
+    async def test_no_priority_fallback_notifies_everyone_as_before(self, _sensor):
+        """Regression: categories without priority_fallback are unaffected."""
+        category = {"id": "alerts"}
+        persons = [
+            _person("person.frank", "home"),
+            _person("person.kevin", "not_home"),
+        ]
+        hass = _make_hass(persons)
+        store = _make_store(category)
+        handler = await _get_handler(hass)
+
+        with _patch_entry(store), patch(
+            "custom_components.ticker.services.async_send_notification",
+            new_callable=AsyncMock,
+        ) as mock_send, patch(
+            "custom_components.ticker.services.build_smart_tag",
+            return_value=None,
+        ):
+            mock_send.return_value = {"delivered": [], "queued": [], "dropped": []}
+            await handler(_make_call("alerts"))
+
+        assert mock_send.await_count == 2


### PR DESCRIPTION
Stacked on #58, merge after #57 and #58.

Two changes to `ticker.notify` so an existing iq_notify setup migrates with just a service-name rename:

- `category` is now optional. Leave it out and the notification goes to the default category instead of erroring. iq_notify call sites have no category, so requiring one meant editing every migrated call.
- `mode` / `mode_window` are now also read from `data.*`, not just the top level. iq_notify nested them inside `data`. #58 added them at the top level; this falls back to the nested form when the top-level key is missing, and pops them so they aren't forwarded to the underlying notify service.

So a bulk `notify.iq_notify` to `ticker.notify` rename becomes find-and-replace, no per-call rewriting.

Touches `service_schema.py` (optional category) and `services.py` (nested mode fallback + pop). The top-level contract from #58 is unchanged; both forms resolve to the same routing logic.