### PR TITLE
Per-category bundle_on_release toggle for queue release

### DIFF
--- a/custom_components/ticker/arrival.py
+++ b/custom_components/ticker/arrival.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_registry import (
 
 from .const import MODE_CONDITIONAL
 from .conditions import evaluate_condition_tree, resolve_zone_name
-from .bundled_notify import async_send_bundled_notification
+from .bundled_notify import async_deliver_released_notifications
 from .recipient_notify import async_send_to_recipient
 
 if TYPE_CHECKING:
@@ -205,14 +205,14 @@ async def async_setup_arrival_listener(
         for queued_entry in entries_to_deliver:
             await store.async_remove_from_queue(queued_entry["queue_id"])
 
-        # Send bundled notification for delivered entries
-        success = await async_send_bundled_notification(
+        # Deliver entries, honoring each category's bundle_on_release flag.
+        failed = await async_deliver_released_notifications(
             hass, person_id, entries_to_deliver, store
         )
 
-        # If sending failed completely, re-queue entries for retry
-        if not success:
-            requeued, discarded = await store.async_requeue_entries(entries_to_deliver)
+        # Re-queue only the entries that failed to deliver.
+        if failed:
+            requeued, discarded = await store.async_requeue_entries(failed)
             if requeued:
                 _LOGGER.warning(
                     "Re-queued %d notifications for %s after delivery failure",
@@ -349,20 +349,23 @@ async def async_release_queue_for_conditions(
     for queued_entry in entries_to_deliver:
         await store.async_remove_from_queue(queued_entry["queue_id"])
 
-    # Route to recipient or person delivery path
+    # Route to recipient or person delivery path. The recipient path returns a
+    # single success bool (re-queue all on failure); the person path already
+    # reports the exact entries that failed, so only those are re-queued.
     if is_recipient:
         success = await _async_deliver_recipient_queue(
             hass, store, person_id, category_id, entries_to_deliver,
         )
+        failed = [] if success else entries_to_deliver
     else:
-        # Send bundled notification for person-based entries
-        success = await async_send_bundled_notification(
+        # Deliver person-based entries, honoring bundle_on_release per category.
+        failed = await async_deliver_released_notifications(
             hass, person_id, entries_to_deliver, store
         )
 
-    # If sending failed, re-queue entries for retry
-    if not success:
-        requeued, discarded = await store.async_requeue_entries(entries_to_deliver)
+    # Re-queue the entries that failed to deliver.
+    if failed:
+        requeued, discarded = await store.async_requeue_entries(failed)
         if requeued:
             _LOGGER.warning(
                 "Re-queued %d notifications for %s after delivery failure",

--- a/custom_components/ticker/bundled_notify.py
+++ b/custom_components/ticker/bundled_notify.py
@@ -279,3 +279,59 @@ async def async_send_bundled_notification(
             )
 
     return any_success
+
+
+async def async_deliver_released_notifications(
+    hass: HomeAssistant,
+    person_id: str,
+    entries: list[dict[str, Any]],
+    store: "TickerStore",
+) -> list[dict[str, Any]]:
+    """Deliver released queue entries, honoring each category's bundle_on_release.
+
+    Entries whose category sets ``bundle_on_release: False`` are delivered one
+    notification per entry, preserving each entry's full title/message/data.
+    All other entries keep the historical behavior: a single bundled summary
+    ("You have N notifications") when more than one is released together.
+
+    ``bundle_on_release`` defaults to True (bundle) via
+    ``category.get("bundle_on_release", True)``, so a store with no such flag
+    on any category behaves exactly as before.
+
+    Args:
+        hass: Home Assistant instance.
+        person_id: The person entity ID.
+        entries: Released queue entries to deliver.
+        store: TickerStore instance.
+
+    Returns:
+        The entries that failed to deliver, for the caller to re-queue. An empty
+        list means everything was delivered.
+    """
+    if not entries:
+        return []
+
+    individual: list[dict[str, Any]] = []
+    bundled: list[dict[str, Any]] = []
+    for entry in entries:
+        category = store.get_category(entry.get("category_id"))
+        if category is not None and category.get("bundle_on_release", True) is False:
+            individual.append(entry)
+        else:
+            bundled.append(entry)
+
+    failed: list[dict[str, Any]] = []
+
+    # Per-entry delivery for opted-out categories. Each single-entry call takes
+    # the count==1 path in async_send_bundled_notification, which forwards the
+    # entry's full payload unchanged.
+    for entry in individual:
+        if not await async_send_bundled_notification(hass, person_id, [entry], store):
+            failed.append(entry)
+
+    # One bundled summary for everything else (unchanged behavior).
+    if bundled:
+        if not await async_send_bundled_notification(hass, person_id, bundled, store):
+            failed.extend(bundled)
+
+    return failed

--- a/custom_components/ticker/frontend/admin/categories-handlers.js
+++ b/custom_components/ticker/frontend/admin/categories-handlers.js
@@ -148,6 +148,7 @@ window.Ticker.AdminCategoriesTab.handlers = {
     const defaultModeEl = root.getElementById(`edit-default-mode-${categoryId}`);
     const defaultMode = defaultModeEl?.value || (cat.default_mode || 'always');
     const criticalEl = root.getElementById(`edit-critical-${categoryId}`);
+    const bundleIndividualEl = root.getElementById(`edit-bundle-individual-${categoryId}`);
     const androidChannelEl = root.getElementById(`edit-android-channel-${categoryId}`);
 
     if (!name) { panel._showError('Name required'); return; }
@@ -155,6 +156,9 @@ window.Ticker.AdminCategoriesTab.handlers = {
     try {
       const params = { type: 'ticker/category/update', category_id: categoryId, name, icon, color };
       if (criticalEl) { params.critical = criticalEl.checked; }
+      // Checked = deliver individually = bundle_on_release false. Unchecked
+      // sends true, which the store treats as the default (removes the key).
+      if (bundleIndividualEl) { params.bundle_on_release = !bundleIndividualEl.checked; }
       if (androidChannelEl) { params.android_channel = androidChannelEl.value.trim() || ''; }
       const navPresetEl = root.getElementById('nav-preset-cat-edit');
       if (navPresetEl) {

--- a/custom_components/ticker/frontend/admin/categories-tab.js
+++ b/custom_components/ticker/frontend/admin/categories-tab.js
@@ -117,6 +117,10 @@ window.Ticker.AdminCategoriesTab = {
   _renderGeneralTab(c, escId, escIcon, escColor) {
     const { escAttr } = window.Ticker.utils;
     const criticalChecked = c.critical ? 'checked' : '';
+    // Opt-out toggle: checked means "deliver individually" (bundle_on_release
+    // false). Default is unchecked (bundle), so the box only shows checked when
+    // the category explicitly stored the flag as false.
+    const individualChecked = c.bundle_on_release === false ? 'checked' : '';
     return `
       <div class="form-row" style="padding-top:8px">
         <div class="form-group">
@@ -141,6 +145,19 @@ window.Ticker.AdminCategoriesTab = {
           <span style="font-size:13px;font-weight:500;color:var(--primary-text-color,#212121)">Critical notifications</span>
           <div style="font-size:12px;color:var(--secondary-text-color,#727272);margin-top:2px">
             Bypass Do Not Disturb and silent mode on recipients' devices
+          </div>
+        </div>
+      </div>
+      <div style="display:flex;align-items:center;gap:10px;margin-top:12px">
+        <label class="toggle" style="margin:0">
+          <input type="checkbox" id="edit-bundle-individual-${escId}" ${individualChecked}>
+          <span class="toggle-slider"></span>
+        </label>
+        <div>
+          <span style="font-size:13px;font-weight:500;color:var(--primary-text-color,#212121)">Deliver queued items individually</span>
+          <div style="font-size:12px;color:var(--secondary-text-color,#727272);margin-top:2px">
+            When multiple queued notifications are released together, send each
+            as its own notification instead of one combined summary
           </div>
         </div>
       </div>

--- a/custom_components/ticker/store/categories.py
+++ b/custom_components/ticker/store/categories.py
@@ -105,6 +105,7 @@ class CategoryMixin:
         android_channel: str | None = None,
         chime_media_content_id: str | None = None,
         volume_override: float | None = None,
+        bundle_on_release: bool | None = None,
     ) -> dict[str, Any]:
         """Create a new category.
 
@@ -165,6 +166,12 @@ class CategoryMixin:
         # is True via category.get("expose_in_sensor", True).
         if expose_in_sensor is False:
             category["expose_in_sensor"] = False
+        # Sparse storage: only persist bundle_on_release when explicitly False.
+        # Read-time default is True via category.get("bundle_on_release", True),
+        # preserving the historical bundle-on-release behavior for every
+        # category that does not opt out.
+        if bundle_on_release is False:
+            category["bundle_on_release"] = False
         if android_channel:
             category["android_channel"] = android_channel
         # F-35: Pre-TTS chime override (sparse — non-empty string only)
@@ -200,6 +207,7 @@ class CategoryMixin:
         chime_media_content_id: str | None = None,
         volume_override: float | None = None,
         clear_volume_override: bool = False,
+        bundle_on_release: bool | None = None,
     ) -> dict[str, Any] | None:
         """Update an existing category.
 
@@ -220,6 +228,12 @@ class CategoryMixin:
             android_channel: If provided, set the Android notification channel ID.
                 A non-empty string is stored; an empty string clears the key
                 (sparse storage). None leaves the current value unchanged.
+            bundle_on_release: If provided, control how queued notifications are
+                delivered when released (on arrival or when conditions are met).
+                None leaves the current value unchanged. True removes the key
+                (default: multiple released entries collapse into one summary).
+                False persists the key so each released entry is delivered as its
+                own notification with its full title/message/data.
         """
         if category_id not in self._categories:
             return None
@@ -266,6 +280,14 @@ class CategoryMixin:
                 category["expose_in_sensor"] = False
             else:
                 category.pop("expose_in_sensor", None)
+
+        # bundle_on_release: sparse — store key only when False. None leaves the
+        # current value unchanged; True restores the default (bundle) behavior.
+        if bundle_on_release is not None:
+            if bundle_on_release is False:
+                category["bundle_on_release"] = False
+            else:
+                category.pop("bundle_on_release", None)
 
         # android_channel: non-empty string sets, empty string clears (sparse)
         if android_channel is not None:

--- a/custom_components/ticker/websocket/categories.py
+++ b/custom_components/ticker/websocket/categories.py
@@ -76,6 +76,7 @@ async def ws_get_categories(
             None, vol.All(str, vol.Length(min=1, max=MAX_NAVIGATE_TO_LENGTH))
         ),
         vol.Optional("expose_in_sensor"): bool,
+        vol.Optional("bundle_on_release"): bool,
         vol.Optional("android_channel"): vol.Any(None, str),
         vol.Optional("chime_media_content_id"): vol.Any(None, str),
         vol.Optional("volume_override"): vol.Any(
@@ -145,6 +146,7 @@ async def ws_create_category(
         return
     expose_in_sensor = msg.get("expose_in_sensor") if "expose_in_sensor" in msg else None
     android_channel = msg.get("android_channel") if "android_channel" in msg else None
+    bundle_on_release = msg.get("bundle_on_release") if "bundle_on_release" in msg else None
 
     # F-35: validate chime_media_content_id length
     chime_id = msg.get("chime_media_content_id")
@@ -176,6 +178,7 @@ async def ws_create_category(
         android_channel=android_channel,
         chime_media_content_id=chime_id,
         volume_override=volume_override,
+        bundle_on_release=bundle_on_release,
     )
 
     connection.send_result(msg["id"], {"category": category})
@@ -205,6 +208,7 @@ async def ws_create_category(
             None, vol.All(str, vol.Length(max=MAX_NAVIGATE_TO_LENGTH))
         ),
         vol.Optional("expose_in_sensor"): bool,
+        vol.Optional("bundle_on_release"): bool,
         vol.Optional("android_channel"): vol.Any(None, str),
         vol.Optional("chime_media_content_id"): vol.Any(None, str),
         vol.Optional("volume_override"): vol.Any(
@@ -288,6 +292,7 @@ async def ws_update_category(
             return
     expose_in_sensor = msg.get("expose_in_sensor") if "expose_in_sensor" in msg else None
     android_channel = msg.get("android_channel") if "android_channel" in msg else None
+    bundle_on_release = msg.get("bundle_on_release") if "bundle_on_release" in msg else None
 
     # F-35: chime_media_content_id — only forwarded when key is present in msg.
     # None or "" clears the override; non-empty sets it. Length-validated here.
@@ -322,6 +327,7 @@ async def ws_update_category(
         navigate_to=navigate_to,
         expose_in_sensor=expose_in_sensor,
         android_channel=android_channel,
+        bundle_on_release=bundle_on_release,
     )
     if chime_id_present:
         # Pass empty string to explicitly clear; non-empty to set

--- a/tests/test_bugfix_044_disabled_user.py
+++ b/tests/test_bugfix_044_disabled_user.py
@@ -265,9 +265,9 @@ class TestReleaseQueueSkipsDisabledUser:
 
     @pytest.mark.asyncio
     @patch(
-        "custom_components.ticker.arrival.async_send_bundled_notification",
+        "custom_components.ticker.arrival.async_deliver_released_notifications",
         new_callable=AsyncMock,
-        return_value=True,
+        return_value=[],
     )
     async def test_enabled_user_queue_released(self, mock_send):
         """Queue release proceeds for an enabled user."""

--- a/tests/test_bugfix_102_zone_id_matching.py
+++ b/tests/test_bugfix_102_zone_id_matching.py
@@ -325,8 +325,8 @@ class TestArrivalReleasesQueue:
         )
 
         with patch(
-            "custom_components.ticker.arrival.async_send_bundled_notification",
-            new=AsyncMock(return_value=True),
+            "custom_components.ticker.arrival.async_deliver_released_notifications",
+            new=AsyncMock(return_value=[]),
         ) as mock_send:
             _run(callback(event))
 
@@ -379,8 +379,8 @@ class TestArrivalReleasesQueue:
         )
 
         with patch(
-            "custom_components.ticker.arrival.async_send_bundled_notification",
-            new=AsyncMock(return_value=True),
+            "custom_components.ticker.arrival.async_deliver_released_notifications",
+            new=AsyncMock(return_value=[]),
         ) as mock_send:
             _run(callback(event))
 
@@ -432,8 +432,8 @@ class TestArrivalReleasesQueue:
         )
 
         with patch(
-            "custom_components.ticker.arrival.async_send_bundled_notification",
-            new=AsyncMock(return_value=True),
+            "custom_components.ticker.arrival.async_deliver_released_notifications",
+            new=AsyncMock(return_value=[]),
         ) as mock_send:
             _run(callback(event))
 

--- a/tests/test_bundle_on_release.py
+++ b/tests/test_bundle_on_release.py
@@ -1,0 +1,321 @@
+"""Tests for the per-category ``bundle_on_release`` toggle.
+
+Covers:
+- Store sparse persistence (create + update) mirroring expose_in_sensor.
+- ``async_deliver_released_notifications`` delivery split: categories that
+  opt out of bundling get one notification per entry; the rest keep the
+  historical single-summary bundle.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.ticker.bundled_notify import (
+    async_deliver_released_notifications,
+)
+from custom_components.ticker.store.categories import CategoryMixin
+from custom_components.ticker.websocket.categories import (
+    ws_create_category,
+    ws_update_category,
+)
+
+
+class _FakeCategoryStore(CategoryMixin):
+    """Concrete CategoryMixin host for store-level assertions."""
+
+    def __init__(self):
+        self.hass = MagicMock()
+        self._categories: dict = {}
+        self._categories_store = MagicMock()
+        self._categories_store.async_save = AsyncMock()
+        self._subscriptions: dict = {}
+        self._category_listeners: list = []
+        self.async_save_subscriptions = AsyncMock()
+
+
+@pytest.fixture
+def cat_store():
+    return _FakeCategoryStore()
+
+
+# ---------------------------------------------------------------------------
+# Delivery split
+# ---------------------------------------------------------------------------
+
+def _entry(queue_id: str, category_id: str) -> dict:
+    return {
+        "queue_id": queue_id,
+        "category_id": category_id,
+        "title": f"T-{queue_id}",
+        "message": f"M-{queue_id}",
+    }
+
+
+def _store(categories: dict[str, dict]) -> MagicMock:
+    store = MagicMock()
+    store.get_category.side_effect = lambda cid: categories.get(cid)
+    return store
+
+
+@pytest.mark.asyncio
+async def test_default_categories_bundle_together():
+    """With no opt-out, all released entries go out as one bundle call."""
+    store = _store({"news": {"name": "News"}})  # no bundle_on_release key
+    entries = [_entry("q1", "news"), _entry("q2", "news")]
+
+    with patch(
+        "custom_components.ticker.bundled_notify.async_send_bundled_notification",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        failed = await async_deliver_released_notifications(
+            MagicMock(), "person.alice", entries, store
+        )
+
+    assert failed == []
+    # One bundled call carrying both entries.
+    assert mock_send.await_count == 1
+    assert mock_send.await_args.args[2] == entries
+
+
+@pytest.mark.asyncio
+async def test_opt_out_category_delivers_per_entry():
+    """bundle_on_release=False -> one send call per entry."""
+    store = _store({"appliance_done": {"bundle_on_release": False}})
+    entries = [_entry("q1", "appliance_done"), _entry("q2", "appliance_done")]
+
+    with patch(
+        "custom_components.ticker.bundled_notify.async_send_bundled_notification",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        failed = await async_deliver_released_notifications(
+            MagicMock(), "person.alice", entries, store
+        )
+
+    assert failed == []
+    assert mock_send.await_count == 2
+    # Each call carries exactly one entry (full payload preserved by the
+    # count==1 path in async_send_bundled_notification).
+    sent = [call.args[2] for call in mock_send.await_args_list]
+    assert [len(s) for s in sent] == [1, 1]
+    assert {s[0]["queue_id"] for s in sent} == {"q1", "q2"}
+
+
+@pytest.mark.asyncio
+async def test_mixed_categories_split():
+    """Opt-out entries go individually; the rest are bundled in one call."""
+    store = _store(
+        {
+            "appliance_done": {"bundle_on_release": False},
+            "news": {"name": "News"},
+        }
+    )
+    entries = [
+        _entry("q1", "appliance_done"),
+        _entry("q2", "news"),
+        _entry("q3", "appliance_done"),
+        _entry("q4", "news"),
+    ]
+
+    with patch(
+        "custom_components.ticker.bundled_notify.async_send_bundled_notification",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        failed = await async_deliver_released_notifications(
+            MagicMock(), "person.alice", entries, store
+        )
+
+    assert failed == []
+    # 2 individual + 1 bundle = 3 calls.
+    assert mock_send.await_count == 3
+    sizes = sorted(len(call.args[2]) for call in mock_send.await_args_list)
+    assert sizes == [1, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_failed_entries_returned_for_requeue():
+    """A failed individual delivery is returned; successes are not."""
+    store = _store({"appliance_done": {"bundle_on_release": False}})
+    entries = [_entry("q1", "appliance_done"), _entry("q2", "appliance_done")]
+
+    # First send succeeds, second fails.
+    with patch(
+        "custom_components.ticker.bundled_notify.async_send_bundled_notification",
+        new=AsyncMock(side_effect=[True, False]),
+    ):
+        failed = await async_deliver_released_notifications(
+            MagicMock(), "person.alice", entries, store
+        )
+
+    assert [e["queue_id"] for e in failed] == ["q2"]
+
+
+@pytest.mark.asyncio
+async def test_empty_entries_short_circuit():
+    store = _store({})
+    with patch(
+        "custom_components.ticker.bundled_notify.async_send_bundled_notification",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        failed = await async_deliver_released_notifications(
+            MagicMock(), "person.alice", [], store
+        )
+    assert failed == []
+    mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_category_defaults_to_bundle():
+    """A missing category (get_category -> None) keeps default bundling."""
+    store = _store({})  # get_category returns None for any id
+    entries = [_entry("q1", "ghost"), _entry("q2", "ghost")]
+
+    with patch(
+        "custom_components.ticker.bundled_notify.async_send_bundled_notification",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        failed = await async_deliver_released_notifications(
+            MagicMock(), "person.alice", entries, store
+        )
+
+    assert failed == []
+    assert mock_send.await_count == 1
+    assert len(mock_send.await_args.args[2]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Store sparse persistence (default True, stored only when False)
+# ---------------------------------------------------------------------------
+
+class TestStorePersistence:
+    @pytest.mark.asyncio
+    async def test_create_false_persists_key(self, cat_store):
+        cat = await cat_store.async_create_category(
+            "appliance_done", "Appliance done", bundle_on_release=False
+        )
+        assert cat["bundle_on_release"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_true_omits_key(self, cat_store):
+        cat = await cat_store.async_create_category(
+            "news", "News", bundle_on_release=True
+        )
+        assert "bundle_on_release" not in cat
+
+    @pytest.mark.asyncio
+    async def test_create_default_omits_key(self, cat_store):
+        cat = await cat_store.async_create_category("news", "News")
+        assert "bundle_on_release" not in cat
+
+    @pytest.mark.asyncio
+    async def test_update_set_false_persists(self, cat_store):
+        await cat_store.async_create_category("appliance_done", "Appliance done")
+        cat = await cat_store.async_update_category(
+            "appliance_done", bundle_on_release=False
+        )
+        assert cat["bundle_on_release"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_set_true_removes_key(self, cat_store):
+        await cat_store.async_create_category(
+            "appliance_done", "Appliance done", bundle_on_release=False
+        )
+        cat = await cat_store.async_update_category(
+            "appliance_done", bundle_on_release=True
+        )
+        assert "bundle_on_release" not in cat
+
+    @pytest.mark.asyncio
+    async def test_update_none_leaves_unchanged(self, cat_store):
+        await cat_store.async_create_category(
+            "appliance_done", "Appliance done", bundle_on_release=False
+        )
+        cat = await cat_store.async_update_category(
+            "appliance_done", name="Renamed"
+        )
+        assert cat["bundle_on_release"] is False
+
+
+# ---------------------------------------------------------------------------
+# WebSocket pass-through
+# ---------------------------------------------------------------------------
+
+def _ws_mocks(exists: bool = True):
+    hass = MagicMock()
+    conn = MagicMock()
+    store = MagicMock()
+    store.category_exists.return_value = exists
+    store.async_create_category = AsyncMock(return_value={"id": "appliance_done"})
+    store.async_update_category = AsyncMock(return_value={"id": "appliance_done"})
+    hass.config_entries.async_entries.return_value = []
+    return hass, conn, store
+
+
+@contextmanager
+def _ws_patches(store):
+    with patch(
+        "custom_components.ticker.websocket.categories.get_store",
+        return_value=store,
+    ), patch(
+        "custom_components.ticker.websocket.categories.validate_category_id",
+        return_value=(True, None),
+    ), patch(
+        "custom_components.ticker.websocket.categories.validate_icon",
+        return_value=(True, None),
+    ), patch(
+        "custom_components.ticker.websocket.categories.validate_color",
+        return_value=(True, None),
+    ), patch(
+        "custom_components.ticker.websocket.categories.validate_navigate_to",
+        return_value=(True, None),
+    ), patch(
+        "custom_components.ticker.websocket.categories.sanitize_for_storage",
+        side_effect=lambda v, _: v,
+    ):
+        yield
+
+
+class TestWebSocketPassThrough:
+    @pytest.mark.asyncio
+    async def test_create_forwards_bundle_on_release(self):
+        hass, conn, store = _ws_mocks(exists=False)
+        msg = {
+            "id": 1,
+            "type": "ticker/category/create",
+            "category_id": "appliance_done",
+            "name": "Appliance done",
+            "bundle_on_release": False,
+        }
+        with _ws_patches(store):
+            await ws_create_category(hass, conn, msg)
+        assert store.async_create_category.await_args.kwargs["bundle_on_release"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_omits_when_absent(self):
+        hass, conn, store = _ws_mocks(exists=False)
+        msg = {
+            "id": 1,
+            "type": "ticker/category/create",
+            "category_id": "news",
+            "name": "News",
+        }
+        with _ws_patches(store):
+            await ws_create_category(hass, conn, msg)
+        # Absent in msg -> None passed -> store keeps default (bundle).
+        assert store.async_create_category.await_args.kwargs["bundle_on_release"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_forwards_bundle_on_release(self):
+        hass, conn, store = _ws_mocks(exists=True)
+        msg = {
+            "id": 2,
+            "type": "ticker/category/update",
+            "category_id": "appliance_done",
+            "bundle_on_release": False,
+        }
+        with _ws_patches(store):
+            await ws_update_category(hass, conn, msg)
+        assert store.async_update_category.await_args.kwargs["bundle_on_release"] is False


### PR DESCRIPTION
When several queued notifications are released at once (on arrival, or when conditions are met), `bundled_notify` collapses them into a single "You have N notifications" summary and drops each entry's message and data (`enriched_data = {}` on the multi-entry path). That's fine for a noisy category, but wrong for a notification queue, where you expect each held item to arrive intact. The single-entry path already keeps the full payload (BUG-080), and the recipient queue path already delivers per-entry, so only the person path collapses. Same module, two behaviors depending on which path you hit.

This adds a per-category `bundle_on_release` flag:
- Default `True`, stored sparsely (persisted only when `False`), same as `expose_in_sensor`. A store with the flag set nowhere behaves exactly as before.
- `False` sends each released entry as its own notification through the existing `count == 1` path, which keeps title/message/data.

`async_deliver_released_notifications` splits released entries by their category's flag: opt-out entries go individually, the rest bundle as before. It returns which entries failed to deliver, so callers re-queue only those instead of the whole batch (before, one failure re-queued everything). The person arrival and condition-release paths call it; the recipient path is unchanged.

Surfaced end to end: store, WebSocket create/update, and a "Deliver queued items individually" toggle in the category editor (checked = opt out of bundling). 15 tests cover the delivery split, sparse persistence, and WS pass-through; full suite 1071 passing.
