### PR TITLE
fix: tts.speak service missing target

### DIFF
--- a/custom_components/ticker/formatting.py
+++ b/custom_components/ticker/formatting.py
@@ -83,6 +83,7 @@ def build_tts_payload(
     message: str,
     entity_id: str,
     tts_service: str | None = None,
+    tts_engine_entity_id: str | None = None,
 ) -> dict[str, Any]:
     """Build a payload for TTS delivery.
 
@@ -90,10 +91,10 @@ def build_tts_payload(
     calling the configured TTS service.
 
     Supports two TTS calling patterns:
-    - **Modern (tts.speak):** entity_id is intentionally omitted because
-      Ticker stores only the media player entity, not the TTS engine
-      entity (e.g., tts.google_translate). HA will use the default
-      TTS engine. media_player_entity_id is the speaker target.
+    - **Modern (tts.speak):** uses media_player_entity_id for the speaker
+      and entity_id for the TTS engine (e.g., tts.google_translate).
+      If tts_engine_entity_id is provided, it's passed as 'entity_id' to
+      select a specific TTS engine.
     - **Legacy (tts.google_translate_say, etc.):** entity_id is the
       media_player directly. This is the default since most users
       use legacy TTS services.
@@ -103,6 +104,8 @@ def build_tts_payload(
         entity_id: The media_player entity ID to speak on.
         tts_service: TTS service (e.g., 'tts.google_translate_say').
             Determines which payload pattern to use.
+        tts_engine_entity_id: TTS engine entity (e.g., 'tts.google_translate')
+            for tts.speak service. Optional.
 
     Returns:
         Payload dict ready for hass.services.async_call.
@@ -110,14 +113,15 @@ def build_tts_payload(
     clean_message = strip_html(message or "")
 
     # Modern tts.speak uses media_player_entity_id as the speaker target
-    # and entity_id as the TTS engine entity (e.g., tts.google_translate).
-    # Ticker only stores the media player, not the TTS engine entity, so
-    # entity_id is omitted — HA will use the default TTS engine.
+    # and optionally entity_id for the TTS engine entity.
     if tts_service and tts_service.lower() == "tts.speak":
-        return {
+        payload: dict[str, Any] = {
             "media_player_entity_id": entity_id,
             "message": clean_message,
         }
+        if tts_engine_entity_id:
+            payload["entity_id"] = tts_engine_entity_id
+        return payload
 
     # Legacy pattern (default): entity_id IS the media_player.
     # Services like tts.google_translate_say, tts.cloud_say, etc.

--- a/custom_components/ticker/frontend/admin/admin-data-loader.js
+++ b/custom_components/ticker/frontend/admin/admin-data-loader.js
@@ -97,10 +97,11 @@ window.Ticker.AdminDataLoader = {
       panel._ttsOptions = {
         media_players: result.media_players || [],
         tts_services: result.tts_services || [],
+        tts_entities: result.tts_entities || [],
       };
     } catch (err) {
       console.error('[Ticker] Failed to load TTS options:', err);
-      panel._ttsOptions = { media_players: [], tts_services: [] };
+      panel._ttsOptions = { media_players: [], tts_services: [], tts_entities: [] };
     }
   },
 

--- a/custom_components/ticker/frontend/admin/recipients-dialog.js
+++ b/custom_components/ticker/frontend/admin/recipients-dialog.js
@@ -21,6 +21,7 @@ window.Ticker.AdminRecipientsDialog = {
     const selectedServices = existing ? (existing.notify_services || []) : [];
     const mediaPlayerEntityId = existing ? (existing.media_player_entity_id || '') : '';
     const ttsService = existing ? (existing.tts_service || '') : '';
+    const ttsEngineEntityId = existing ? (existing.tts_engine_entity_id || '') : '';
 
     const nameSection = this._renderNameSection(isEdit, existing, escAttr, name);
     const iconSection = this._renderIconField(escAttr, icon);
@@ -33,7 +34,7 @@ window.Ticker.AdminRecipientsDialog = {
     // F-35.2: volume override (0.0–1.0); null = inherit (no override).
     const rawVol = existing ? existing.volume_override : null;
     const volume = (typeof rawVol === 'number' && rawVol >= 0 && rawVol <= 1) ? rawVol : null;
-    const ttsFields = this._renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, deviceType, resumeAfterTts, bufferDelay, chimeId, volume);
+    const ttsFields = this._renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, ttsEngineEntityId, deviceType, resumeAfterTts, bufferDelay, chimeId, volume);
 
     return `
       <div id="recipient-dialog-overlay" style="position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:100;display:flex;align-items:center;justify-content:center" onclick="if(event.target===this)window.Ticker.AdminRecipientsTab.handlers.closeDialog(window.Ticker._adminPanel)">
@@ -171,10 +172,10 @@ window.Ticker.AdminRecipientsDialog = {
     `;
   },
 
-  /** Render TTS-specific fields: media player entity + TTS service + resume toggle + chime. */
-  _renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, deviceType, resumeAfterTts, bufferDelay, chimeId, volumeOverride) {
+  /** Render TTS-specific fields: media player entity + TTS service + TTS engine + resume toggle + chime. */
+  _renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, ttsEngineEntityId, deviceType, resumeAfterTts, bufferDelay, chimeId, volumeOverride) {
     const { esc } = window.Ticker.utils;
-    const ttsOptions = panel._ttsOptions || { media_players: [], tts_services: [] };
+    const ttsOptions = panel._ttsOptions || { media_players: [], tts_services: [], tts_entities: [] };
     const ns = 'window.Ticker.AdminRecipientsDialog';
 
     // Build media player dropdown options
@@ -189,11 +190,20 @@ window.Ticker.AdminRecipientsDialog = {
       return `<option value="${escAttr(svc.service_id)}" ${selected}>${esc(svc.name)} (${esc(svc.service_id)})</option>`;
     }).join('');
 
+    // Build TTS engine entity dropdown options (for tts.speak with target engine)
+    const ttsEngineOpts = ttsOptions.tts_entities.map(ent => {
+      const selected = ent.entity_id === ttsEngineEntityId ? 'selected' : '';
+      return `<option value="${escAttr(ent.entity_id)}" ${selected}>${esc(ent.friendly_name)} (${esc(ent.entity_id)})</option>`;
+    }).join('');
+
     const noMpMsg = ttsOptions.media_players.length === 0
       ? '<span style="font-size:11px;color:var(--ticker-warning-dark);margin-top:2px;display:block">No media_player entities found in Home Assistant</span>'
       : '';
     const noTtsMsg = ttsOptions.tts_services.length === 0
       ? '<span style="font-size:11px;color:var(--ticker-warning-dark);margin-top:2px;display:block">No TTS services found in Home Assistant</span>'
+      : '';
+    const noTtsEngineMsg = ttsOptions.tts_entities.length === 0
+      ? '<span style="font-size:11px;color:var(--text-secondary);margin-top:2px;display:block">No TTS engine entities found (optional for tts.speak)</span>'
       : '';
 
     // Announce support indicator for initially selected media player
@@ -218,6 +228,15 @@ window.Ticker.AdminRecipientsDialog = {
         </select>
         ${noTtsMsg}
         <span style="font-size:11px;color:var(--text-secondary);margin-top:2px;display:block">The text-to-speech service to use</span>
+      </div>
+      <div class="form-group" style="margin-bottom:12px">
+        <label>TTS Engine Entity (optional)</label>
+        <select class="form-select" id="dlg-tts-engine">
+          <option value="">-- None (use default) --</option>
+          ${ttsEngineOpts}
+        </select>
+        ${noTtsEngineMsg}
+        <span style="font-size:11px;color:var(--text-secondary);margin-top:2px;display:block">For tts.speak: selects which TTS engine to use. For other services this is ignored.</span>
       </div>
       <div style="display:flex;align-items:center;gap:8px;margin-top:8px">
         <label class="toggle">

--- a/custom_components/ticker/frontend/admin/recipients-handlers.js
+++ b/custom_components/ticker/frontend/admin/recipients-handlers.js
@@ -298,6 +298,12 @@ window.Ticker.AdminRecipientsTab.handlers = {
       }
       wsMsg.media_player_entity_id = mediaPlayer;
       wsMsg.tts_service = container.querySelector('#dlg-tts-service')?.value?.trim() || 'tts.google_translate_say';
+      const ttsEngine = container.querySelector('#dlg-tts-engine')?.value?.trim();
+      if (ttsEngine) {
+        wsMsg.tts_engine_entity_id = ttsEngine;
+      } else if (isEdit) {
+        wsMsg.tts_engine_entity_id = '';
+      }
       wsMsg.resume_after_tts = !!container.querySelector('#dlg-resume-tts')?.checked;
       wsMsg.tts_buffer_delay = parseFloat(container.querySelector('#dlg-tts-buffer-delay')?.value) || 0;
       // F-35: Pre-TTS chime — omit when empty (sparse). On edit, send "" to clear.

--- a/custom_components/ticker/recipient_tts.py
+++ b/custom_components/ticker/recipient_tts.py
@@ -156,7 +156,8 @@ async def async_send_tts(
         return results
 
     tts_service = recipient.get("tts_service") or "tts.speak"
-    payload = build_tts_payload(message, entity_id, tts_service)
+    tts_engine_entity_id = recipient.get("tts_engine_entity_id")
+    payload = build_tts_payload(message, entity_id, tts_service, tts_engine_entity_id)
 
     # F-35 §5.2: pre-playback delay (Chromecast). Runs BEFORE the chime.
     buffer_delay = recipient.get("tts_buffer_delay", TTS_BUFFER_DELAY_DEFAULT)

--- a/custom_components/ticker/store/recipients.py
+++ b/custom_components/ticker/store/recipients.py
@@ -80,6 +80,7 @@ class RecipientMixin:
         device_type: str = DEVICE_TYPE_PUSH,
         media_player_entity_id: str | None = None,
         tts_service: str | None = None,
+        tts_engine_entity_id: str | None = None,
         resume_after_tts: bool = False,
         tts_buffer_delay: float = TTS_BUFFER_DELAY_DEFAULT,
         conditions: dict[str, Any] | None = None,
@@ -100,6 +101,8 @@ class RecipientMixin:
             device_type: 'push' or 'tts'.
             media_player_entity_id: Media player entity for TTS devices.
             tts_service: TTS service (e.g., 'tts.google_translate_say').
+            tts_engine_entity_id: TTS engine entity (e.g., 'tts.google_translate')
+                for services like tts.speak that support it.
             resume_after_tts: Whether to resume media after TTS playback.
             tts_buffer_delay: Seconds to wait before TTS playback (Chromecast).
             conditions: Device-level conditions dict (time/state rules).
@@ -148,6 +151,7 @@ class RecipientMixin:
             "delivery_format": delivery_format,
             "media_player_entity_id": media_player_entity_id,
             "tts_service": tts_service,
+            "tts_engine_entity_id": tts_engine_entity_id,
             "resume_after_tts": resume_after_tts,
             "tts_buffer_delay": tts_buffer_delay,
             "enabled": enabled,
@@ -171,6 +175,20 @@ class RecipientMixin:
         elif device_type != DEVICE_TYPE_TTS and chime_media_content_id:
             _LOGGER.debug(
                 "Dropping chime_media_content_id on non-TTS recipient %s",
+                recipient_id,
+            )
+
+        # Sparse storage for tts_engine_entity_id — only persist on TTS devices
+        # when a non-empty value was supplied. Push devices silently drop.
+        if (
+            device_type == DEVICE_TYPE_TTS
+            and tts_engine_entity_id
+            and tts_engine_entity_id.strip()
+        ):
+            recipient["tts_engine_entity_id"] = tts_engine_entity_id.strip()
+        elif device_type != DEVICE_TYPE_TTS and tts_engine_entity_id:
+            _LOGGER.debug(
+                "Dropping tts_engine_entity_id on non-TTS recipient %s",
                 recipient_id,
             )
 
@@ -218,7 +236,7 @@ class RecipientMixin:
         allowed_fields = {
             "name", "icon", "notify_services", "delivery_format", "enabled",
             "device_type", "media_player_entity_id", "tts_service",
-            "resume_after_tts", "tts_buffer_delay", "conditions",
+            "tts_engine_entity_id", "resume_after_tts", "tts_buffer_delay", "conditions",
             "chime_media_content_id", "volume_override",
         }
         unknown = set(kwargs) - allowed_fields
@@ -255,6 +273,15 @@ class RecipientMixin:
                     else:
                         self._recipients[recipient_id].pop(
                             "volume_override", None,
+                        )
+                elif key == "tts_engine_entity_id":
+                    # Sparse storage — strip + remove key when blank
+                    cleaned = (value or "").strip() if isinstance(value, str) else ""
+                    if cleaned:
+                        self._recipients[recipient_id]["tts_engine_entity_id"] = cleaned
+                    else:
+                        self._recipients[recipient_id].pop(
+                            "tts_engine_entity_id", None,
                         )
                 else:
                     self._recipients[recipient_id][key] = value
@@ -466,6 +493,7 @@ class RecipientMixin:
 
             recipient.setdefault("media_player_entity_id", None)
             recipient.setdefault("tts_service", None)
+            recipient.setdefault("tts_engine_entity_id", None)
             recipient.setdefault("resume_after_tts", False)
             recipient.setdefault("tts_buffer_delay", TTS_BUFFER_DELAY_DEFAULT)
             migrated += 1

--- a/custom_components/ticker/websocket/recipient_helpers.py
+++ b/custom_components/ticker/websocket/recipient_helpers.py
@@ -82,9 +82,20 @@ async def ws_get_tts_options(
             "name": service_name,
         })
 
+    # Collect TTS engine entities (for tts.speak with target engine selection)
+    tts_entities = []
+    for state in hass.states.async_all("tts"):
+        friendly_name = state.attributes.get("friendly_name", state.entity_id)
+        tts_entities.append({
+            "entity_id": state.entity_id,
+            "friendly_name": friendly_name,
+        })
+    tts_entities.sort(key=lambda x: x["friendly_name"].lower())
+
     connection.send_result(msg["id"], {
         "media_players": media_players,
         "tts_services": tts_services,
+        "tts_entities": tts_entities,
     })
 
 

--- a/custom_components/ticker/websocket/recipients.py
+++ b/custom_components/ticker/websocket/recipients.py
@@ -153,6 +153,7 @@ async def ws_get_recipients(
         vol.Optional("delivery_format", default=DELIVERY_FORMAT_RICH): str,
         vol.Optional("media_player_entity_id"): str,
         vol.Optional("tts_service"): str,
+        vol.Optional("tts_engine_entity_id"): str,
         vol.Optional("icon", default="mdi:bell-ring"): str,
         vol.Optional("enabled", default=True): bool,
         vol.Optional("resume_after_tts", default=False): bool,
@@ -241,6 +242,7 @@ async def ws_create_recipient(
             delivery_format=msg["delivery_format"],
             media_player_entity_id=msg.get("media_player_entity_id"),
             tts_service=msg.get("tts_service"),
+            tts_engine_entity_id=msg.get("tts_engine_entity_id"),
             icon=msg["icon"],
             enabled=msg["enabled"],
             resume_after_tts=msg["resume_after_tts"],
@@ -267,6 +269,7 @@ async def ws_create_recipient(
         vol.Optional("delivery_format"): str,
         vol.Optional("media_player_entity_id"): str,
         vol.Optional("tts_service"): str,
+        vol.Optional("tts_engine_entity_id"): str,
         vol.Optional("icon"): str,
         vol.Optional("enabled"): bool,
         vol.Optional("resume_after_tts"): bool,
@@ -343,6 +346,9 @@ async def ws_update_recipient(
 
     if "tts_service" in msg:
         kwargs["tts_service"] = msg["tts_service"]
+
+    if "tts_engine_entity_id" in msg:
+        kwargs["tts_engine_entity_id"] = msg["tts_engine_entity_id"]
 
     if "icon" in msg:
         is_valid, error = validate_icon(msg["icon"])


### PR DESCRIPTION
When using `tts.speak`, it is required to set the entity id, see docs:
https://www.home-assistant.io/actions/tts.speak/#using-this-action-in-yaml

Currently there's no way to set this, so I added it as an additional optional selector.

Disclaimer: I used AI to make code this PR but tested it on my HA instance and got it working.

This should fix #45, but this issue only talks about the "test notification" feature. In reality, notifications using `tts.speak` don't work at all.
