### PR TITLE
fix(tts): route notify.-entity recipients through notify.send_message

### DIFF
--- a/custom_components/ticker/formatting.py
+++ b/custom_components/ticker/formatting.py
@@ -109,6 +109,16 @@ def build_tts_payload(
     """
     clean_message = strip_html(message or "")
 
+    # Amazon Alexa (alexa_devices integration) rejects tts.speak/play_media
+    # ("music is not available as a music provider"). Recipients configured
+    # with a notify.-entity tts_service must be delivered via that entity's
+    # own service call, targeting itself as entity_id.
+    if tts_service and tts_service.lower().startswith("notify."):
+        return {
+            "entity_id": tts_service,
+            "message": clean_message,
+        }
+
     # Modern tts.speak uses media_player_entity_id as the speaker target
     # and entity_id as the TTS engine entity (e.g., tts.google_translate).
     # Ticker only stores the media player, not the TTS engine entity, so

--- a/custom_components/ticker/recipient_tts_delivery.py
+++ b/custom_components/ticker/recipient_tts_delivery.py
@@ -109,6 +109,12 @@ async def _call_tts_service(
 ) -> None:
     """Call the TTS service with a timeout."""
     domain, service_name = tts_service.split(".", 1)
+    # notify.-entity recipients (e.g. Alexa via alexa_devices) are delivered
+    # through the generic notify.send_message action, not a per-entity
+    # service — the entity itself is the payload's entity_id (see
+    # formatting.build_tts_payload).
+    if domain == "notify":
+        service_name = "send_message"
     await asyncio.wait_for(
         hass.services.async_call(domain, service_name, payload, blocking=True),
         timeout=NOTIFY_SERVICE_TIMEOUT,


### PR DESCRIPTION
## Summary
- Recipients whose `tts_service` is a `notify.`-domain entity (e.g. Amazon Alexa via the `alexa_devices` integration) fail delivery today: HA raises `Action notify.<slug> not found`, because `_call_tts_service` tries to invoke the notify entity's slug as a standalone service instead of calling the generic `notify.send_message` action with the entity as target.
- Amazon Alexa additionally rejects the `tts.speak`/`play_media` delivery path outright (`ValueError: music is not available as a music provider`), so for these recipients `notify.send_message` is the only working route.
- `build_tts_payload`: when `tts_service` starts with `notify.`, build `{entity_id: tts_service, message}` instead of targeting the media player entity.
- `_call_tts_service`: when the service domain is `notify`, always call `send_message` instead of treating the second segment as a literal service name.

## Test plan
- [x] Configured a `tts` recipient with `tts_service: notify.<alexa notify entity>` pointing at an Amazon Echo device (via `alexa_devices`) and confirmed TTS delivery succeeds end-to-end (chime + speech) where it previously failed with `Action notify.<slug> not found` / `ValueError('music is not available as a music provider')`.
- [x] Confirmed existing `tts.*` recipients (Sonos, HA Voice, NSPanel) are unaffected — `build_tts_payload`/`_call_tts_service` behavior for non-`notify.` services is unchanged.