### PR TITLE
feat: make TTS engine and chime timing configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For the full feature guide, see [USER_GUIDE.md](custom_components/ticker/USER_GU
 - **Smart notification management** - Auto-grouping, auto-tagging, sticky/persistent flags, and `ticker.clear_notification` service injected automatically at delivery time *(v1.5.0)*
 - **Notification navigation target** - `navigate_to` parameter on `ticker.notify` deep-links to any HA panel on notification tap, with a live navigation picker in the admin panel *(v1.5.0)*
 - **Pre-TTS chime** - configure an audio chime that plays through the target media_player immediately before each TTS announcement, set per recipient with optional per-category override; ships three bundled CC0 chime presets (subtle/alert/doorbell) so the feature is functional out-of-box *(v1.7.0)*
+- **Selectable modern TTS engine** - `tts.speak` recipients can target a specific Home Assistant TTS entity such as OpenAI TTS, while legacy TTS services remain supported
+- **Per-recipient chime timing** - tune the detected-chime timeout and fallback chime-to-speech gap without editing integration source files
 - **Volume override** - 0–100 % slider on the device and category dialogs sets the media_player volume for the chime+TTS pair, then restores the previous level after TTS finishes playing. Leave on "Default" to inherit the device's current volume *(v1.7.0)*
 - **Admin-assisted household setup** - admins can operate the user panel on another household member's behalf using a "Viewing as" dropdown in the panel header, making it easy to configure subscriptions and conditions for non-technical users without sharing credentials *(v1.7.0)*
 - **Multi-category fan-out** - `category` field accepts a list of category IDs so a single `ticker.notify` call can target multiple categories at once *(v1.6.0)*

--- a/custom_components/ticker/USER_GUIDE.md
+++ b/custom_components/ticker/USER_GUIDE.md
@@ -417,7 +417,7 @@ Each recipient has a device type that determines how Ticker delivers the notific
 
 **Push** — Ticker calls one or more notify services, the same way it does for person devices. The delivery format (rich or plain) is auto-detected from the service identifier and can be overridden by the admin. Use this for TVs with the `nfandroidtv` integration, persistent notifications, or any notify-based target.
 
-**TTS** — Ticker calls `tts.speak` targeting a media player entity. Use this for speakers or voice assistants. The admin selects the media player and optionally a TTS service from dropdowns populated from live HA data.
+**TTS** — Ticker calls a TTS service targeting a media player entity. Use this for speakers or voice assistants. The admin selects the media player and TTS service from dropdowns populated from live HA data. When using modern `tts.speak`, a separate **TTS Engine Entity** dropdown selects the provider (for example `tts.openai_tts` or `tts.home_assistant_cloud`). Existing legacy services such as `tts.cloud_say` continue to work without an engine entity.
 
 ### TTS delivery
 
@@ -442,7 +442,7 @@ Where it is configured:
 
 Both dialogs include a Test Chime button that plays the chime through the chosen media_player without going through the queue, sending TTS, or producing a History entry.
 
-The chime is fail-soft: if the media_player is offline, the asset is missing, or playback fails for any reason, the failure is logged as a warning and the TTS announcement still delivers normally — the History entry is still marked as Sent. TTS proceeds no more than 10 seconds after the chime starts playing on platforms that expose the chime in `media_content_id`; on platforms that never expose it (or the chime can't be detected within ~1.5 s), TTS proceeds after a fixed 3-second gap. Either way, a stuck or silent chime will never block the announcement indefinitely.
+The chime is fail-soft: if the media_player is offline, the asset is missing, or playback fails for any reason, the failure is logged as a warning and the TTS announcement still delivers normally — the History entry is still marked as Sent. The recipient dialog exposes two timing controls: **Chime wait timeout** caps how long Ticker waits for a detected-but-stuck chime (default 10 seconds), while **Fallback gap** controls the total delay when the player never exposes chime playback state (default 3 seconds). Short chimes on responsive local players can use a smaller fallback such as 1 second; slower Cast targets and longer chimes may need the defaults or higher values.
 
 **Caveat — Alexa double-chime:** Some TTS engines (notably Amazon Alexa via the Alexa Media Player integration) play their own "earcon" tone before speech. If Ticker also plays a chime, the listener hears two tones in a row. Ticker does not auto-detect this — leave the chime field empty for Alexa-based recipients to avoid the double-chime.
 

--- a/custom_components/ticker/const.py
+++ b/custom_components/ticker/const.py
@@ -147,6 +147,8 @@ MEDIA_ANNOUNCE_FEATURE = 524288
 # before kicking off the TTS service call. Most chime assets are
 # 0.5–3 seconds; 10s tolerates a slow Chromecast buffer + 3s jingle.
 CHIME_WAIT_TIMEOUT = 10.0
+CHIME_WAIT_TIMEOUT_MIN = 0.5
+CHIME_WAIT_TIMEOUT_MAX = 60.0
 # Fixed delay (seconds) between the chime play_media call and the TTS
 # service call. State polling (`_wait_for_state_exit`) was unreliable
 # across platforms — HA Voice in particular keeps the entity in
@@ -158,6 +160,8 @@ CHIME_WAIT_TIMEOUT = 10.0
 # warm Nabu connections). Chime assets longer than this gap will
 # overlap with TTS — documented limitation.
 CHIME_TTS_GAP = 3.0
+CHIME_TTS_GAP_MIN = 0.0
+CHIME_TTS_GAP_MAX = 10.0
 ATTR_CHIME_MEDIA_CONTENT_ID = "chime_media_content_id"
 MAX_CHIME_MEDIA_CONTENT_ID_LENGTH = 500
 

--- a/custom_components/ticker/formatting.py
+++ b/custom_components/ticker/formatting.py
@@ -83,6 +83,7 @@ def build_tts_payload(
     message: str,
     entity_id: str,
     tts_service: str | None = None,
+    tts_entity_id: str | None = None,
 ) -> dict[str, Any]:
     """Build a payload for TTS delivery.
 
@@ -90,10 +91,10 @@ def build_tts_payload(
     calling the configured TTS service.
 
     Supports two TTS calling patterns:
-    - **Modern (tts.speak):** entity_id is intentionally omitted because
-      Ticker stores only the media player entity, not the TTS engine
-      entity (e.g., tts.google_translate). HA will use the default
-      TTS engine. media_player_entity_id is the speaker target.
+    - **Modern (tts.speak):** media_player_entity_id is the speaker target;
+      entity_id selects the TTS engine when one is configured (for example,
+      tts.openai_tts). The engine is omitted for backward compatibility when
+      older recipient data has no tts_entity_id.
     - **Legacy (tts.google_translate_say, etc.):** entity_id is the
       media_player directly. This is the default since most users
       use legacy TTS services.
@@ -103,6 +104,7 @@ def build_tts_payload(
         entity_id: The media_player entity ID to speak on.
         tts_service: TTS service (e.g., 'tts.google_translate_say').
             Determines which payload pattern to use.
+        tts_entity_id: Optional TTS engine entity used by ``tts.speak``.
 
     Returns:
         Payload dict ready for hass.services.async_call.
@@ -110,14 +112,15 @@ def build_tts_payload(
     clean_message = strip_html(message or "")
 
     # Modern tts.speak uses media_player_entity_id as the speaker target
-    # and entity_id as the TTS engine entity (e.g., tts.google_translate).
-    # Ticker only stores the media player, not the TTS engine entity, so
-    # entity_id is omitted — HA will use the default TTS engine.
+    # and entity_id as the TTS engine entity (e.g., tts.openai_tts).
     if tts_service and tts_service.lower() == "tts.speak":
-        return {
+        payload = {
             "media_player_entity_id": entity_id,
             "message": clean_message,
         }
+        if tts_entity_id:
+            payload["entity_id"] = tts_entity_id
+        return payload
 
     # Legacy pattern (default): entity_id IS the media_player.
     # Services like tts.google_translate_say, tts.cloud_say, etc.

--- a/custom_components/ticker/frontend/admin/admin-data-loader.js
+++ b/custom_components/ticker/frontend/admin/admin-data-loader.js
@@ -97,10 +97,11 @@ window.Ticker.AdminDataLoader = {
       panel._ttsOptions = {
         media_players: result.media_players || [],
         tts_services: result.tts_services || [],
+        tts_entities: result.tts_entities || [],
       };
     } catch (err) {
       console.error('[Ticker] Failed to load TTS options:', err);
-      panel._ttsOptions = { media_players: [], tts_services: [] };
+      panel._ttsOptions = { media_players: [], tts_services: [], tts_entities: [] };
     }
   },
 

--- a/custom_components/ticker/frontend/admin/recipients-dialog.js
+++ b/custom_components/ticker/frontend/admin/recipients-dialog.js
@@ -20,7 +20,8 @@ window.Ticker.AdminRecipientsDialog = {
     const format = existing ? (existing.delivery_format || 'rich') : 'rich';
     const selectedServices = existing ? (existing.notify_services || []) : [];
     const mediaPlayerEntityId = existing ? (existing.media_player_entity_id || '') : '';
-    const ttsService = existing ? (existing.tts_service || '') : '';
+    const ttsService = existing ? (existing.tts_service || 'tts.speak') : 'tts.speak';
+    const ttsEntityId = existing ? (existing.tts_entity_id || '') : '';
 
     const nameSection = this._renderNameSection(isEdit, existing, escAttr, name);
     const iconSection = this._renderIconField(escAttr, icon);
@@ -30,10 +31,12 @@ window.Ticker.AdminRecipientsDialog = {
     const bufferDelay = existing ? (existing.tts_buffer_delay ?? 0) : 0;
     // F-35: Pre-TTS chime media_content_id (sparse: missing/empty == no chime)
     const chimeId = existing ? (existing.chime_media_content_id || '') : '';
+    const chimeWaitTimeout = existing ? (existing.chime_wait_timeout ?? 10) : 10;
+    const chimeTtsGap = existing ? (existing.chime_tts_gap ?? 3) : 3;
     // F-35.2: volume override (0.0–1.0); null = inherit (no override).
     const rawVol = existing ? existing.volume_override : null;
     const volume = (typeof rawVol === 'number' && rawVol >= 0 && rawVol <= 1) ? rawVol : null;
-    const ttsFields = this._renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, deviceType, resumeAfterTts, bufferDelay, chimeId, volume);
+    const ttsFields = this._renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, ttsEntityId, deviceType, resumeAfterTts, bufferDelay, chimeId, volume, chimeWaitTimeout, chimeTtsGap);
 
     return `
       <div id="recipient-dialog-overlay" style="position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:100;display:flex;align-items:center;justify-content:center" onclick="if(event.target===this)window.Ticker.AdminRecipientsTab.handlers.closeDialog(window.Ticker._adminPanel)">
@@ -172,33 +175,30 @@ window.Ticker.AdminRecipientsDialog = {
   },
 
   /** Render TTS-specific fields: media player entity + TTS service + resume toggle + chime. */
-  _renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, deviceType, resumeAfterTts, bufferDelay, chimeId, volumeOverride) {
+  _renderTtsFields(panel, escAttr, mediaPlayerEntityId, ttsService, ttsEntityId, deviceType, resumeAfterTts, bufferDelay, chimeId, volumeOverride, chimeWaitTimeout, chimeTtsGap) {
     const { esc } = window.Ticker.utils;
     const ttsOptions = panel._ttsOptions || { media_players: [], tts_services: [] };
     const ns = 'window.Ticker.AdminRecipientsDialog';
-
     // Build media player dropdown options
     const mpOptions = ttsOptions.media_players.map(mp => {
       const selected = mp.entity_id === mediaPlayerEntityId ? 'selected' : '';
       return `<option value="${escAttr(mp.entity_id)}" ${selected}>${esc(mp.friendly_name)} (${esc(mp.entity_id)})</option>`;
     }).join('');
-
     // Build TTS service dropdown options
     const ttsOpts = ttsOptions.tts_services.map(svc => {
       const selected = svc.service_id === ttsService ? 'selected' : '';
       return `<option value="${escAttr(svc.service_id)}" ${selected}>${esc(svc.name)} (${esc(svc.service_id)})</option>`;
     }).join('');
-
+    const ttsConfig = window.Ticker.AdminRecipientTtsConfig;
+    const engineHtml = ttsConfig.renderEngine(esc, escAttr, ttsOptions, ttsService, ttsEntityId), timingHtml = ttsConfig.renderTiming(chimeWaitTimeout, chimeTtsGap);
     const noMpMsg = ttsOptions.media_players.length === 0
       ? '<span style="font-size:11px;color:var(--ticker-warning-dark);margin-top:2px;display:block">No media_player entities found in Home Assistant</span>'
       : '';
     const noTtsMsg = ttsOptions.tts_services.length === 0
       ? '<span style="font-size:11px;color:var(--ticker-warning-dark);margin-top:2px;display:block">No TTS services found in Home Assistant</span>'
       : '';
-
     // Announce support indicator for initially selected media player
     const announceHtml = this._getAnnounceIndicator(ttsOptions, mediaPlayerEntityId);
-
     return `
       <div class="form-group" style="margin-bottom:12px">
         <label>Media Player Entity</label>
@@ -212,13 +212,14 @@ window.Ticker.AdminRecipientsDialog = {
       </div>
       <div class="form-group" style="margin-bottom:12px">
         <label>TTS Service</label>
-        <select class="form-select" id="dlg-tts-service">
+        <select class="form-select" id="dlg-tts-service" onchange="window.Ticker.AdminRecipientTtsConfig.onServiceChange(window.Ticker._adminPanel)">
           <option value="">-- Select TTS service --</option>
           ${ttsOpts}
         </select>
         ${noTtsMsg}
         <span style="font-size:11px;color:var(--text-secondary);margin-top:2px;display:block">The text-to-speech service to use</span>
       </div>
+      ${engineHtml}
       <div style="display:flex;align-items:center;gap:8px;margin-top:8px">
         <label class="toggle">
           <input type="checkbox" id="dlg-resume-tts" ${resumeAfterTts ? 'checked' : ''}>
@@ -233,6 +234,7 @@ window.Ticker.AdminRecipientsDialog = {
       </div>
       ${window.Ticker.AdminVolumeOverride.render('dlg', volumeOverride)}
       ${this._renderChimeSection(escAttr, chimeId || '')}
+      ${timingHtml}
     `;
   },
 
@@ -371,6 +373,7 @@ window.Ticker.AdminRecipientsDialog = {
     if (mp && mp.value) return true;
     const tts = container.querySelector('#dlg-tts-service');
     if (tts && tts.value) return true;
+    if (window.Ticker.AdminRecipientTtsConfig.hasValues(container)) return true;
     const resume = container.querySelector('#dlg-resume-tts');
     if (resume && resume.checked) return true;
     if (parseFloat(container.querySelector('#dlg-tts-buffer-delay')?.value) > 0) return true;
@@ -394,13 +397,14 @@ window.Ticker.AdminRecipientsDialog = {
     const mp = container.querySelector('#dlg-media-player');
     if (mp) mp.value = '';
     const tts = container.querySelector('#dlg-tts-service');
-    if (tts) tts.value = '';
+    if (tts) tts.value = 'tts.speak';
     const resume = container.querySelector('#dlg-resume-tts');
     if (resume) resume.checked = false;
     const indicator = container.querySelector('#dlg-announce-indicator');
     if (indicator) indicator.innerHTML = '';
     const bufferEl = container.querySelector('#dlg-tts-buffer-delay');
     if (bufferEl) bufferEl.value = '0';
+    window.Ticker.AdminRecipientTtsConfig.clear(container);
     // F-35: also clear the chime fields
     const chimeDisplay = container.querySelector('#dlg-chime-display');
     if (chimeDisplay) chimeDisplay.value = '';

--- a/custom_components/ticker/frontend/admin/recipients-handlers.js
+++ b/custom_components/ticker/frontend/admin/recipients-handlers.js
@@ -297,9 +297,17 @@ window.Ticker.AdminRecipientsTab.handlers = {
         return;
       }
       wsMsg.media_player_entity_id = mediaPlayer;
-      wsMsg.tts_service = container.querySelector('#dlg-tts-service')?.value?.trim() || 'tts.google_translate_say';
+      wsMsg.tts_service = container.querySelector('#dlg-tts-service')?.value?.trim() || 'tts.speak';
+      const ttsEntityId = container.querySelector('#dlg-tts-entity')?.value?.trim() || '';
+      if (wsMsg.tts_service.toLowerCase() === 'tts.speak' && ttsEntityId) {
+        wsMsg.tts_entity_id = ttsEntityId;
+      } else if (isEdit) {
+        wsMsg.tts_entity_id = '';
+      }
       wsMsg.resume_after_tts = !!container.querySelector('#dlg-resume-tts')?.checked;
       wsMsg.tts_buffer_delay = parseFloat(container.querySelector('#dlg-tts-buffer-delay')?.value) || 0;
+      wsMsg.chime_wait_timeout = parseFloat(container.querySelector('#dlg-chime-wait-timeout')?.value) || 10;
+      wsMsg.chime_tts_gap = parseFloat(container.querySelector('#dlg-chime-tts-gap')?.value) || 0;
       // F-35: Pre-TTS chime — omit when empty (sparse). On edit, send "" to clear.
       const chimeId = (container.querySelector('#dlg-chime-id')?.value || '').trim();
       if (chimeId) {

--- a/custom_components/ticker/frontend/admin/recipients-tts-config.js
+++ b/custom_components/ticker/frontend/admin/recipients-tts-config.js
@@ -1,0 +1,53 @@
+/** TTS engine and chime timing controls for the recipient dialog. */
+window.Ticker = window.Ticker || {};
+
+window.Ticker.AdminRecipientTtsConfig = {
+  renderEngine(esc, escAttr, ttsOptions, ttsService, ttsEntityId) {
+    const options = (ttsOptions.tts_entities || []).map(entity => {
+      const selected = entity.entity_id === ttsEntityId ? 'selected' : '';
+      return `<option value="${escAttr(entity.entity_id)}" ${selected}>${esc(entity.friendly_name)} (${esc(entity.entity_id)})</option>`;
+    }).join('');
+    const visible = ttsService.toLowerCase() === 'tts.speak' ? 'block' : 'none';
+    return `
+      <div class="form-group" id="dlg-tts-entity-group" style="margin-bottom:12px;display:${visible}">
+        <label>TTS Engine Entity</label>
+        <select class="form-select" id="dlg-tts-entity">
+          <option value="">-- Use Home Assistant default --</option>
+          ${options}
+        </select>
+        <span style="font-size:11px;color:var(--text-secondary);margin-top:2px;display:block">Selects the engine used by tts.speak, such as OpenAI TTS.</span>
+      </div>`;
+  },
+
+  renderTiming(waitTimeout, fallbackGap) {
+    return `
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px">
+        <div><label style="display:block;margin-bottom:4px;font-size:13px;color:var(--text-secondary)">Chime wait timeout (seconds)</label><input type="number" id="dlg-chime-wait-timeout" min="0.5" max="60" step="0.5" value="${waitTimeout}" style="width:100%;padding:6px 8px;border-radius:4px;border:1px solid var(--divider);background:var(--bg-card);color:var(--text-primary)"></div>
+        <div><label style="display:block;margin-bottom:4px;font-size:13px;color:var(--text-secondary)">Fallback gap (seconds)</label><input type="number" id="dlg-chime-tts-gap" min="0" max="10" step="0.5" value="${fallbackGap}" style="width:100%;padding:6px 8px;border-radius:4px;border:1px solid var(--divider);background:var(--bg-card);color:var(--text-primary)"></div>
+      </div>
+      <p style="margin:4px 0 0;font-size:11px;color:var(--text-secondary)">Timeout caps a stuck chime state. Fallback gap is used when the player does not expose chime playback state.</p>`;
+  },
+
+  onServiceChange(panel) {
+    const root = panel.shadowRoot.getElementById('ticker-dialog-container');
+    if (!root) return;
+    const service = root.querySelector('#dlg-tts-service')?.value || '';
+    const group = root.querySelector('#dlg-tts-entity-group');
+    if (group) group.style.display = service.toLowerCase() === 'tts.speak' ? 'block' : 'none';
+  },
+
+  hasValues(root) {
+    return !!root.querySelector('#dlg-tts-entity')?.value;
+  },
+
+  clear(root) {
+    const engine = root.querySelector('#dlg-tts-entity');
+    if (engine) engine.value = '';
+    const group = root.querySelector('#dlg-tts-entity-group');
+    if (group) group.style.display = 'block';
+    const wait = root.querySelector('#dlg-chime-wait-timeout');
+    if (wait) wait.value = '10';
+    const gap = root.querySelector('#dlg-chime-tts-gap');
+    if (gap) gap.value = '3';
+  },
+};

--- a/custom_components/ticker/frontend/ticker-admin-panel.js
+++ b/custom_components/ticker/frontend/ticker-admin-panel.js
@@ -30,7 +30,7 @@ class TickerAdminPanel extends HTMLElement {
     this._scripts = [];
     this._recipients = [];
     this._availableNotifyServices = [];
-    this._ttsOptions = { media_players: [], tts_services: [] };
+    this._ttsOptions = { media_players: [], tts_services: [], tts_entities: [] };
     this._lovelaceDashboards = [];
     this._hasPanels = [];
     this._lovelaceViews = {};
@@ -183,6 +183,7 @@ class TickerAdminPanel extends HTMLElement {
       `${base}/admin/recipients-handlers.js`,
       `${base}/admin/recipients-link-handlers.js`,
       `${base}/admin/recipients-volume.js`,
+      `${base}/admin/recipients-tts-config.js`,
       `${base}/admin/recipients-dialog.js`,
       `${base}/admin/queue-tab.js`,
       `${base}/admin/logs-tab.js`,

--- a/custom_components/ticker/recipient_tts.py
+++ b/custom_components/ticker/recipient_tts.py
@@ -19,6 +19,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
+    CHIME_TTS_GAP,
+    CHIME_WAIT_TIMEOUT,
     LOG_OUTCOME_FAILED,
     LOG_OUTCOME_SENT,
     MEDIA_ANNOUNCE_FEATURE,
@@ -170,7 +172,10 @@ async def async_send_tts(
         return results
 
     tts_service = recipient.get("tts_service") or "tts.speak"
-    payload = build_tts_payload(message, entity_id, tts_service)
+    tts_entity_id = recipient.get("tts_entity_id")
+    payload = build_tts_payload(
+        message, entity_id, tts_service, tts_entity_id=tts_entity_id,
+    )
 
     # F-35 §5.2: pre-playback delay (Chromecast). Runs BEFORE the chime.
     buffer_delay = recipient.get("tts_buffer_delay", TTS_BUFFER_DELAY_DEFAULT)
@@ -187,6 +192,10 @@ async def async_send_tts(
     except Exception:  # noqa: BLE001
         category = None
     chime_id = _resolve_chime(recipient, category)
+    chime_wait_timeout = recipient.get(
+        "chime_wait_timeout", CHIME_WAIT_TIMEOUT,
+    )
+    chime_tts_gap = recipient.get("chime_tts_gap", CHIME_TTS_GAP)
 
     # F-35.2: explicit caller-supplied volume wins (test-chime path);
     # otherwise resolve recipient default vs. category override.
@@ -209,16 +218,22 @@ async def async_send_tts(
                 method = await _deliver_tts_announce(
                     hass, entity_id, tts_service, payload,
                     chime_id=chime_id, volume_level=volume_level,
+                    chime_wait_timeout=chime_wait_timeout,
+                    chime_tts_gap=chime_tts_gap,
                 )
             elif resume:
                 method = await _deliver_tts_with_restore(
                     hass, entity_id, tts_service, payload,
                     chime_id=chime_id, volume_level=volume_level,
+                    chime_wait_timeout=chime_wait_timeout,
+                    chime_tts_gap=chime_tts_gap,
                 )
             else:
                 method = await _deliver_tts_plain(
                     hass, entity_id, tts_service, payload,
                     chime_id=chime_id, volume_level=volume_level,
+                    chime_wait_timeout=chime_wait_timeout,
+                    chime_tts_gap=chime_tts_gap,
                 )
 
         svc_display = f"{tts_service} -> {entity_id} [{method}]"

--- a/custom_components/ticker/recipient_tts_chime.py
+++ b/custom_components/ticker/recipient_tts_chime.py
@@ -40,7 +40,6 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-
 # ---------------------------------------------------------------------------
 # BUG-109 iteration 2: cast-platform detection
 # ---------------------------------------------------------------------------
@@ -84,6 +83,7 @@ async def _wait_for_chime_complete(
     entity_id: str,
     chime_url: str,
     timeout: float = CHIME_WAIT_TIMEOUT,
+    fallback_gap: float = CHIME_TTS_GAP,
     poll_interval: float = 0.2,
     detect_window: float = 1.5,
 ) -> None:
@@ -128,10 +128,12 @@ async def _wait_for_chime_complete(
         current = state.attributes.get("media_content_id") or ""
         return chime_marker in current or current == chime_url
 
-    # Phase 1: wait briefly for the chime to register on the entity
+    # Cap detection to configured budgets so a 1.0s fallback gap does not
+    # still block for the default ~1.5s detection window.
+    effective_detect_window = min(detect_window, timeout, fallback_gap)
     elapsed = 0.0
     started = False
-    while elapsed < detect_window:
+    while elapsed < effective_detect_window:
         if _is_chime_now():
             started = True
             _LOGGER.debug(
@@ -145,11 +147,11 @@ async def _wait_for_chime_complete(
     if not started:
         # Platform doesn't expose chime in content_id — fall back to
         # the fixed gap so we still give the chime time to play.
-        fallback = max(0.0, CHIME_TTS_GAP - elapsed)
+        fallback = max(0.0, fallback_gap - elapsed)
         _LOGGER.debug(
             "Pre-TTS chime: not observed in content_id on %s within "
             "%.1fs; falling back to %.1fs fixed delay",
-            entity_id, detect_window, fallback,
+            entity_id, effective_detect_window, fallback,
         )
         await asyncio.sleep(fallback)
         return
@@ -200,6 +202,8 @@ async def _play_chime(
     chime_id: str,
     announce: bool = False,
     volume_level: float | None = None,
+    chime_wait_timeout: float = CHIME_WAIT_TIMEOUT,
+    chime_tts_gap: float = CHIME_TTS_GAP,
 ) -> None:
     """F-35: Play a pre-TTS chime on entity_id, fail-soft.
 
@@ -300,7 +304,11 @@ async def _play_chime(
         # content_id (HA Voice, most cast/Sonos integrations). For
         # platforms that never expose the chime in content_id we fall
         # back to a CHIME_TTS_GAP fixed delay.
-        await _wait_for_chime_complete(hass, entity_id, chime_id)
+        await _wait_for_chime_complete(
+            hass, entity_id, chime_id,
+            timeout=chime_wait_timeout,
+            fallback_gap=chime_tts_gap,
+        )
     finally:
         if snapshot_volume is not None:
             # Cast: use jiggle for restore (still needs the cache-busting

--- a/custom_components/ticker/recipient_tts_delivery.py
+++ b/custom_components/ticker/recipient_tts_delivery.py
@@ -44,6 +44,8 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from .const import (
+    CHIME_TTS_GAP,
+    CHIME_WAIT_TIMEOUT,
     NOTIFY_SERVICE_TIMEOUT,
     TTS_PLAYBACK_MAX_TIMEOUT,
     TTS_PLAYBACK_START_TIMEOUT,
@@ -165,6 +167,8 @@ async def _deliver_tts_announce(
     payload: dict[str, Any],
     chime_id: str | None = None,
     volume_level: float | None = None,
+    chime_wait_timeout: float = CHIME_WAIT_TIMEOUT,
+    chime_tts_gap: float = CHIME_TTS_GAP,
 ) -> str:
     """Deliver TTS via announce mode (platform handles pause/resume).
 
@@ -200,7 +204,11 @@ async def _deliver_tts_announce(
             )
     try:
         if chime_id:
-            await _play_chime(hass, entity_id, chime_id, announce=True)
+            await _play_chime(
+                hass, entity_id, chime_id, announce=True,
+                chime_wait_timeout=chime_wait_timeout,
+                chime_tts_gap=chime_tts_gap,
+            )
         await _call_tts_service(hass, tts_service, payload)
     finally:
         if snap_vol is not None and vol_target is not None:
@@ -215,6 +223,8 @@ async def _deliver_tts_with_restore(
     payload: dict[str, Any],
     chime_id: str | None = None,
     volume_level: float | None = None,
+    chime_wait_timeout: float = CHIME_WAIT_TIMEOUT,
+    chime_tts_gap: float = CHIME_TTS_GAP,
 ) -> str:
     """Deliver TTS with manual snapshot/restore of media state.
 
@@ -274,7 +284,11 @@ async def _deliver_tts_with_restore(
             await _set_volume(hass, entity_id, vol_target)
 
     if chime_id:
-        await _play_chime(hass, entity_id, chime_id)
+        await _play_chime(
+            hass, entity_id, chime_id,
+            chime_wait_timeout=chime_wait_timeout,
+            chime_tts_gap=chime_tts_gap,
+        )
 
     await _call_tts_service(hass, tts_service, payload)
 
@@ -339,6 +353,8 @@ async def _deliver_tts_plain(
     payload: dict[str, Any],
     chime_id: str | None = None,
     volume_level: float | None = None,
+    chime_wait_timeout: float = CHIME_WAIT_TIMEOUT,
+    chime_tts_gap: float = CHIME_TTS_GAP,
 ) -> str:
     """Deliver TTS with no announce or restore — plain fire-and-forget.
 
@@ -385,7 +401,11 @@ async def _deliver_tts_plain(
 
     try:
         if chime_id:
-            await _play_chime(hass, entity_id, chime_id)
+            await _play_chime(
+                hass, entity_id, chime_id,
+                chime_wait_timeout=chime_wait_timeout,
+                chime_tts_gap=chime_tts_gap,
+            )
         await _call_tts_service(hass, tts_service, payload)
         if snap_vol is not None:
             # Wait for TTS to start playing.

--- a/custom_components/ticker/store/recipients.py
+++ b/custom_components/ticker/store/recipients.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 from ..const import (
     ATTR_USER_LINK,
+    CHIME_TTS_GAP,
+    CHIME_WAIT_TIMEOUT,
     DELIVERY_FORMAT_RICH,
     DELIVERY_FORMAT_TTS,
     DEVICE_TYPE_PUSH,
@@ -24,7 +26,6 @@ from ..const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
 
 class RecipientMixin:
     """Mixin providing recipient (non-user device) functionality for TickerStore.
@@ -80,11 +81,14 @@ class RecipientMixin:
         device_type: str = DEVICE_TYPE_PUSH,
         media_player_entity_id: str | None = None,
         tts_service: str | None = None,
+        tts_entity_id: str | None = None,
         resume_after_tts: bool = False,
         tts_buffer_delay: float = TTS_BUFFER_DELAY_DEFAULT,
         conditions: dict[str, Any] | None = None,
         chime_media_content_id: str | None = None,
         volume_override: float | None = None,
+        chime_wait_timeout: float = CHIME_WAIT_TIMEOUT,
+        chime_tts_gap: float = CHIME_TTS_GAP,
     ) -> dict[str, Any]:
         """Create a new recipient.
 
@@ -100,6 +104,7 @@ class RecipientMixin:
             device_type: 'push' or 'tts'.
             media_player_entity_id: Media player entity for TTS devices.
             tts_service: TTS service (e.g., 'tts.google_translate_say').
+            tts_entity_id: TTS engine entity used by modern ``tts.speak``.
             resume_after_tts: Whether to resume media after TTS playback.
             tts_buffer_delay: Seconds to wait before TTS playback (Chromecast).
             conditions: Device-level conditions dict (time/state rules).
@@ -148,8 +153,11 @@ class RecipientMixin:
             "delivery_format": delivery_format,
             "media_player_entity_id": media_player_entity_id,
             "tts_service": tts_service,
+            "tts_entity_id": tts_entity_id,
             "resume_after_tts": resume_after_tts,
             "tts_buffer_delay": tts_buffer_delay,
+            "chime_wait_timeout": float(chime_wait_timeout),
+            "chime_tts_gap": float(chime_tts_gap),
             "enabled": enabled,
             "created_at": now,
             "updated_at": now,
@@ -218,8 +226,9 @@ class RecipientMixin:
         allowed_fields = {
             "name", "icon", "notify_services", "delivery_format", "enabled",
             "device_type", "media_player_entity_id", "tts_service",
-            "resume_after_tts", "tts_buffer_delay", "conditions",
+            "tts_entity_id", "resume_after_tts", "tts_buffer_delay", "conditions",
             "chime_media_content_id", "volume_override",
+            "chime_wait_timeout", "chime_tts_gap",
         }
         unknown = set(kwargs) - allowed_fields
         if unknown:
@@ -233,6 +242,12 @@ class RecipientMixin:
                 if key == "conditions" and value is None:
                     # Sparse storage: remove conditions key when cleared
                     self._recipients[recipient_id].pop("conditions", None)
+                elif key == "tts_entity_id":
+                    cleaned = value.strip() if isinstance(value, str) else ""
+                    if cleaned:
+                        self._recipients[recipient_id]["tts_entity_id"] = cleaned
+                    else:
+                        self._recipients[recipient_id].pop("tts_entity_id", None)
                 elif key == "chime_media_content_id":
                     # F-35: sparse storage — strip + remove key when blank
                     cleaned = (value or "").strip() if isinstance(value, str) else ""
@@ -449,8 +464,11 @@ class RecipientMixin:
                 # Ensure TTS fields exist even on already-migrated data
                 recipient.setdefault("media_player_entity_id", None)
                 recipient.setdefault("tts_service", None)
+                recipient.setdefault("tts_entity_id", None)
                 recipient.setdefault("resume_after_tts", False)
                 recipient.setdefault("tts_buffer_delay", TTS_BUFFER_DELAY_DEFAULT)
+                recipient.setdefault("chime_wait_timeout", CHIME_WAIT_TIMEOUT)
+                recipient.setdefault("chime_tts_gap", CHIME_TTS_GAP)
                 continue
 
             old_format = recipient.get("delivery_format", DELIVERY_FORMAT_RICH)
@@ -466,8 +484,11 @@ class RecipientMixin:
 
             recipient.setdefault("media_player_entity_id", None)
             recipient.setdefault("tts_service", None)
+            recipient.setdefault("tts_entity_id", None)
             recipient.setdefault("resume_after_tts", False)
             recipient.setdefault("tts_buffer_delay", TTS_BUFFER_DELAY_DEFAULT)
+            recipient.setdefault("chime_wait_timeout", CHIME_WAIT_TIMEOUT)
+            recipient.setdefault("chime_tts_gap", CHIME_TTS_GAP)
             migrated += 1
             _LOGGER.info(
                 "Migrated recipient %s: device_type=%s (was format=%s)",

--- a/custom_components/ticker/websocket/recipient_helpers.py
+++ b/custom_components/ticker/websocket/recipient_helpers.py
@@ -58,6 +58,8 @@ async def ws_get_tts_options(
     Returns:
         media_players: list of {entity_id, friendly_name} for all media_player entities.
         tts_services: list of {service_id, name} for all tts.* services.
+        tts_entities: list of {entity_id, friendly_name} for modern
+            ``tts.speak`` engine selection.
     """
     # Collect media_player entities
     media_players = []
@@ -82,9 +84,20 @@ async def ws_get_tts_options(
             "name": service_name,
         })
 
+    tts_entities = []
+    for state in hass.states.async_all("tts"):
+        tts_entities.append({
+            "entity_id": state.entity_id,
+            "friendly_name": state.attributes.get(
+                "friendly_name", state.entity_id,
+            ),
+        })
+    tts_entities.sort(key=lambda item: item["friendly_name"].lower())
+
     connection.send_result(msg["id"], {
         "media_players": media_players,
         "tts_services": tts_services,
+        "tts_entities": tts_entities,
     })
 
 

--- a/custom_components/ticker/websocket/recipients.py
+++ b/custom_components/ticker/websocket/recipients.py
@@ -21,6 +21,12 @@ from homeassistant.core import HomeAssistant
 
 from ..const import (
     ATTR_USER_LINK,
+    CHIME_TTS_GAP,
+    CHIME_TTS_GAP_MAX,
+    CHIME_TTS_GAP_MIN,
+    CHIME_WAIT_TIMEOUT,
+    CHIME_WAIT_TIMEOUT_MAX,
+    CHIME_WAIT_TIMEOUT_MIN,
     DEVICE_TYPE_PUSH,
     DEVICE_TYPE_TTS,
     DEVICE_TYPES,
@@ -57,6 +63,15 @@ _VOLUME_SCHEMA = vol.Any(
         vol.Coerce(float),
         vol.Range(min=VOLUME_OVERRIDE_MIN, max=VOLUME_OVERRIDE_MAX),
     ),
+)
+
+_CHIME_WAIT_TIMEOUT_SCHEMA = vol.All(
+    vol.Coerce(float),
+    vol.Range(min=CHIME_WAIT_TIMEOUT_MIN, max=CHIME_WAIT_TIMEOUT_MAX),
+)
+_CHIME_TTS_GAP_SCHEMA = vol.All(
+    vol.Coerce(float),
+    vol.Range(min=CHIME_TTS_GAP_MIN, max=CHIME_TTS_GAP_MAX),
 )
 
 
@@ -153,6 +168,7 @@ async def ws_get_recipients(
         vol.Optional("delivery_format", default=DELIVERY_FORMAT_RICH): str,
         vol.Optional("media_player_entity_id"): str,
         vol.Optional("tts_service"): str,
+        vol.Optional("tts_entity_id"): str,
         vol.Optional("icon", default="mdi:bell-ring"): str,
         vol.Optional("enabled", default=True): bool,
         vol.Optional("resume_after_tts", default=False): bool,
@@ -162,6 +178,8 @@ async def ws_get_recipients(
         vol.Optional("conditions"): vol.Any(dict, None),
         vol.Optional("chime_media_content_id"): vol.Any(None, str),
         vol.Optional("volume_override"): _VOLUME_SCHEMA,
+        vol.Optional("chime_wait_timeout", default=CHIME_WAIT_TIMEOUT): _CHIME_WAIT_TIMEOUT_SCHEMA,
+        vol.Optional("chime_tts_gap", default=CHIME_TTS_GAP): _CHIME_TTS_GAP_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -199,6 +217,14 @@ async def ws_create_recipient(
     )
     if not is_valid:
         connection.send_error(msg["id"], err_code, err_msg)
+        return
+
+    tts_entity_id = msg.get("tts_entity_id")
+    if tts_entity_id and not tts_entity_id.startswith("tts."):
+        connection.send_error(
+            msg["id"], "invalid_tts_entity",
+            "tts_entity_id must start with 'tts.'",
+        )
         return
 
     # Validate delivery_format only for push devices
@@ -241,6 +267,7 @@ async def ws_create_recipient(
             delivery_format=msg["delivery_format"],
             media_player_entity_id=msg.get("media_player_entity_id"),
             tts_service=msg.get("tts_service"),
+            tts_entity_id=msg.get("tts_entity_id"),
             icon=msg["icon"],
             enabled=msg["enabled"],
             resume_after_tts=msg["resume_after_tts"],
@@ -248,6 +275,10 @@ async def ws_create_recipient(
             conditions=conditions,
             chime_media_content_id=chime_id,
             volume_override=volume_override,
+            chime_wait_timeout=msg.get(
+                "chime_wait_timeout", CHIME_WAIT_TIMEOUT,
+            ),
+            chime_tts_gap=msg.get("chime_tts_gap", CHIME_TTS_GAP),
         )
     except ValueError as err:
         connection.send_error(msg["id"], "create_failed", str(err))
@@ -267,6 +298,7 @@ async def ws_create_recipient(
         vol.Optional("delivery_format"): str,
         vol.Optional("media_player_entity_id"): str,
         vol.Optional("tts_service"): str,
+        vol.Optional("tts_entity_id"): str,
         vol.Optional("icon"): str,
         vol.Optional("enabled"): bool,
         vol.Optional("resume_after_tts"): bool,
@@ -276,6 +308,8 @@ async def ws_create_recipient(
         vol.Optional("conditions"): vol.Any(dict, None),
         vol.Optional("chime_media_content_id"): vol.Any(None, str),
         vol.Optional("volume_override"): _VOLUME_SCHEMA,
+        vol.Optional("chime_wait_timeout"): _CHIME_WAIT_TIMEOUT_SCHEMA,
+        vol.Optional("chime_tts_gap"): _CHIME_TTS_GAP_SCHEMA,
     }
 )
 @websocket_api.async_response
@@ -344,6 +378,16 @@ async def ws_update_recipient(
     if "tts_service" in msg:
         kwargs["tts_service"] = msg["tts_service"]
 
+    if "tts_entity_id" in msg:
+        tts_entity_id = msg["tts_entity_id"]
+        if tts_entity_id and not tts_entity_id.startswith("tts."):
+            connection.send_error(
+                msg["id"], "invalid_tts_entity",
+                "tts_entity_id must start with 'tts.'",
+            )
+            return
+        kwargs["tts_entity_id"] = tts_entity_id
+
     if "icon" in msg:
         is_valid, error = validate_icon(msg["icon"])
         if not is_valid:
@@ -359,6 +403,12 @@ async def ws_update_recipient(
 
     if "tts_buffer_delay" in msg:
         kwargs["tts_buffer_delay"] = msg["tts_buffer_delay"]
+
+    if "chime_wait_timeout" in msg:
+        kwargs["chime_wait_timeout"] = msg["chime_wait_timeout"]
+
+    if "chime_tts_gap" in msg:
+        kwargs["chime_tts_gap"] = msg["chime_tts_gap"]
 
     # F-21: Device-level conditions (None clears via sparse storage).
     # BUG-093: empty dict normalizes to None, same as explicit None.

--- a/tests/test_f35_chime_delivery.py
+++ b/tests/test_f35_chime_delivery.py
@@ -358,6 +358,27 @@ class TestChimeFailSoft:
 
     @pytest.mark.asyncio
     @patch(
+        "custom_components.ticker.recipient_tts_delivery.asyncio.sleep",
+        new_callable=AsyncMock,
+    )
+    async def test_recipient_can_shorten_chime_fallback_gap(self, mock_sleep):
+        hass = _make_hass(entity_id="media_player.kitchen", features=0)
+        store = _make_store(category=None)
+        recipient = _make_recipient(chime="media-source://x")
+        recipient["chime_wait_timeout"] = 3.0
+        recipient["chime_tts_gap"] = 1.0
+
+        await async_send_tts(
+            hass, store, recipient, "cat1", "Title", "Hello",
+        )
+
+        sleep_durations = [
+            call.args[0] for call in mock_sleep.await_args_list if call.args
+        ]
+        assert sum(sleep_durations) == pytest.approx(1.0, abs=0.3)
+
+    @pytest.mark.asyncio
+    @patch(
         "custom_components.ticker.recipient_tts_delivery._wait_for_state_exit",
         new_callable=AsyncMock, return_value=True,
     )

--- a/tests/test_feature_tts_engine_options.py
+++ b/tests/test_feature_tts_engine_options.py
@@ -1,0 +1,76 @@
+"""Tests for modern TTS engine discovery in the recipient editor."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import voluptuous as vol
+
+from custom_components.ticker.websocket.recipient_helpers import ws_get_tts_options
+from custom_components.ticker.websocket.recipients import (
+    _CHIME_TTS_GAP_SCHEMA,
+    _CHIME_WAIT_TIMEOUT_SCHEMA,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_tts_options_returns_engine_entities():
+    hass = MagicMock()
+    hass.states.async_all.side_effect = lambda domain: {
+        "media_player": [
+            SimpleNamespace(
+                entity_id="media_player.bedroom",
+                attributes={"friendly_name": "Bedroom", "supported_features": 0},
+            ),
+        ],
+        "tts": [
+            SimpleNamespace(
+                entity_id="tts.openai_tts",
+                attributes={"friendly_name": "OpenAI TTS"},
+            ),
+            SimpleNamespace(
+                entity_id="tts.home_assistant_cloud",
+                attributes={"friendly_name": "Home Assistant Cloud"},
+            ),
+        ],
+    }[domain]
+    hass.services.async_services.return_value = {
+        "tts": {"speak": object(), "cloud_say": object()},
+    }
+    connection = MagicMock()
+
+    await ws_get_tts_options(
+        hass, connection, {"id": 7, "type": "ticker/get_tts_options"},
+    )
+
+    result = connection.send_result.call_args.args[1]
+    assert result["tts_entities"] == [
+        {
+            "entity_id": "tts.home_assistant_cloud",
+            "friendly_name": "Home Assistant Cloud",
+        },
+        {"entity_id": "tts.openai_tts", "friendly_name": "OpenAI TTS"},
+    ]
+    assert {item["service_id"] for item in result["tts_services"]} == {
+        "tts.cloud_say",
+        "tts.speak",
+    }
+
+
+def test_chime_timing_schemas_accept_supported_values():
+    assert _CHIME_WAIT_TIMEOUT_SCHEMA("3") == 3.0
+    assert _CHIME_TTS_GAP_SCHEMA("1") == 1.0
+
+
+@pytest.mark.parametrize(
+    ("schema", "value"),
+    [
+        (_CHIME_WAIT_TIMEOUT_SCHEMA, 0.4),
+        (_CHIME_WAIT_TIMEOUT_SCHEMA, 60.1),
+        (_CHIME_TTS_GAP_SCHEMA, -0.1),
+        (_CHIME_TTS_GAP_SCHEMA, 10.1),
+    ],
+)
+def test_chime_timing_schemas_reject_out_of_range(schema, value):
+    with pytest.raises(vol.Invalid):
+        schema(value)

--- a/tests/test_fix001_tts_media_player_lock.py
+++ b/tests/test_fix001_tts_media_player_lock.py
@@ -89,7 +89,8 @@ class _ConcurrencyProbe:
         self._hold = hold
 
     async def __call__(self, hass, entity_id, tts_service, payload,
-                        *, chime_id=None, volume_level=None):
+                        *, chime_id=None, volume_level=None,
+                        chime_wait_timeout=None, chime_tts_gap=None):
         self.active += 1
         self.max_active = max(self.max_active, self.active)
         self.events.append(f"start:{entity_id}")

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -327,6 +327,19 @@ class TestBuildTtsPayload:
         )
         assert "media_player_entity_id" in result
 
+    def test_modern_tts_speak_with_explicit_engine(self):
+        result = build_tts_payload(
+            "Good night",
+            "media_player.bedroom",
+            tts_service="tts.speak",
+            tts_entity_id="tts.openai_tts",
+        )
+        assert result == {
+            "entity_id": "tts.openai_tts",
+            "media_player_entity_id": "media_player.bedroom",
+            "message": "Good night",
+        }
+
     def test_none_message_becomes_empty_string(self):
         result = build_tts_payload(None, "media_player.kitchen")
         assert result["message"] == ""

--- a/tests/test_recipient_tts.py
+++ b/tests/test_recipient_tts.py
@@ -534,6 +534,43 @@ class TestAsyncSendTts:
         assert call_args[0][1] == "google_translate_say"
 
     @pytest.mark.asyncio
+    async def test_modern_tts_uses_configured_engine_entity(self):
+        """tts.speak targets the configured engine entity when present."""
+        hass = _make_hass(entity_id="media_player.kitchen", features=0)
+        store = _make_store()
+        recipient = _make_recipient(tts_service="tts.speak")
+        recipient["tts_entity_id"] = "tts.openai_tts"
+
+        await async_send_tts(
+            hass, store, recipient, "cat1", "Title", "Hello",
+        )
+
+        payload = hass.services.async_call.call_args[0][2]
+        assert payload["entity_id"] == "tts.openai_tts"
+        assert payload["media_player_entity_id"] == "media_player.kitchen"
+
+    @pytest.mark.asyncio
+    async def test_recipient_chime_timing_reaches_delivery(self):
+        """Per-recipient chime timing overrides reach the delivery branch."""
+        hass = _make_hass(entity_id="media_player.kitchen", features=0)
+        store = _make_store()
+        recipient = _make_recipient()
+        recipient["chime_wait_timeout"] = 3.0
+        recipient["chime_tts_gap"] = 1.0
+
+        with patch(
+            "custom_components.ticker.recipient_tts._deliver_tts_plain",
+            new_callable=AsyncMock,
+            return_value="plain",
+        ) as deliver:
+            await async_send_tts(
+                hass, store, recipient, "cat1", "Title", "Hello",
+            )
+
+        assert deliver.await_args.kwargs["chime_wait_timeout"] == 3.0
+        assert deliver.await_args.kwargs["chime_tts_gap"] == 1.0
+
+    @pytest.mark.asyncio
     async def test_success_logs_sent_outcome(self):
         """Successful delivery logs with LOG_OUTCOME_SENT."""
         hass = _make_hass(entity_id="media_player.kitchen", features=0)

--- a/tests/test_store_recipients.py
+++ b/tests/test_store_recipients.py
@@ -275,6 +275,21 @@ class TestCreateRecipientDeviceType:
         assert result["tts_service"] == "tts.google_translate_say"
 
     @pytest.mark.asyncio
+    async def test_create_tts_engine_and_chime_timing(self, store):
+        result = await store.async_create_recipient(
+            "speaker1", "Kitchen Speaker", [],
+            device_type=DEVICE_TYPE_TTS,
+            media_player_entity_id="media_player.kitchen",
+            tts_service="tts.speak",
+            tts_entity_id="tts.openai_tts",
+            chime_wait_timeout=3.0,
+            chime_tts_gap=1.0,
+        )
+        assert result["tts_entity_id"] == "tts.openai_tts"
+        assert result["chime_wait_timeout"] == 3.0
+        assert result["chime_tts_gap"] == 1.0
+
+    @pytest.mark.asyncio
     async def test_create_tts_overrides_delivery_format(self, store):
         """TTS device type ignores delivery_format and stores 'rich' default."""
         result = await store.async_create_recipient(
@@ -313,6 +328,24 @@ class TestCreateRecipientDeviceType:
         )
         assert result["media_player_entity_id"] == "media_player.new"
         assert result["tts_service"] == "tts.cloud_say"
+
+    @pytest.mark.asyncio
+    async def test_update_and_clear_tts_engine(self, store):
+        await store.async_create_recipient(
+            "speaker1", "Speaker", [], device_type=DEVICE_TYPE_TTS,
+        )
+        result = await store.async_update_recipient(
+            "speaker1", tts_entity_id="tts.openai_tts",
+            chime_wait_timeout=3.0, chime_tts_gap=1.0,
+        )
+        assert result["tts_entity_id"] == "tts.openai_tts"
+        assert result["chime_wait_timeout"] == 3.0
+        assert result["chime_tts_gap"] == 1.0
+
+        result = await store.async_update_recipient(
+            "speaker1", tts_entity_id="",
+        )
+        assert "tts_entity_id" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add per-recipient TTS engine entity selection for modern `tts.speak`
- Add configurable chime wait timeout and fallback gap per recipient
- Preserve legacy TTS services and the existing 10s/3s defaults

## Motivation

Some media players do not expose short chimes through `media_content_id`.
Ticker then relies on a fixed fallback delay, which can create unnecessary
silence before the spoken message.

Modern Home Assistant TTS providers, including OpenAI, are also exposed as
entities used with `tts.speak`, while Ticker currently only allows users to
select a TTS service.

## Implementation

- Discover available `tts.*` entities alongside TTS services
- Store an optional `tts_entity_id` for each recipient
- Pass the selected engine as the target of `tts.speak`
- Add `chime_wait_timeout` with a supported range of 0.5–60 seconds
- Add `chime_tts_gap` with a supported range of 0–10 seconds
- Cap the detection window according to the configured timing budgets, allowing
  gaps shorter than the previous detection window
- Add the corresponding admin UI controls and documentation
- Preserve existing recipients and legacy TTS configurations

## Testing

- Full test suite: 1125 passed
- Targeted TTS and chime tests: 207 passed
- Python compile check
- JavaScript syntax parsing for the changed frontend modules
- `git diff --check`

